### PR TITLE
feat(errors): rename ErrorCategory.Functional to Business

### DIFF
--- a/src/libraries/Hexalith.Commons/Errors/ErrorCategory.cs
+++ b/src/libraries/Hexalith.Commons/Errors/ErrorCategory.cs
@@ -16,9 +16,9 @@ public enum ErrorCategory
     Unknown = 0,
 
     /// <summary>
-    /// Functional error type.
+    /// Business error type.
     /// </summary>
-    Functional = 1,
+    Business = 1,
 
     /// <summary>
     /// Technical error type.

--- a/test/Hexalith.Commons.Tests/Errors/ApplicationErrorTest.cs
+++ b/test/Hexalith.Commons.Tests/Errors/ApplicationErrorTest.cs
@@ -27,13 +27,13 @@ public class ApplicationErrorTest
         {
             Title = "Error",
             Detail = "Detail",
-            Category = ErrorCategory.Functional,
+            Category = ErrorCategory.Business,
         };
         ApplicationError error2 = new()
         {
             Title = "Error",
             Detail = "Detail",
-            Category = ErrorCategory.Functional,
+            Category = ErrorCategory.Business,
         };
 
         // Assert


### PR DESCRIPTION
Rename the Functional enum value to Business for clearer semantics when categorizing error types.