### PR TITLE
feat(unique-ids): add sortable ULID-based unique ID generation

### DIFF
--- a/_bmad-output/implementation-artifacts/1-1-add-byteaether-ulid-package-dependency.md
+++ b/_bmad-output/implementation-artifacts/1-1-add-byteaether-ulid-package-dependency.md
@@ -1,0 +1,180 @@
+# Story 1.1: Add ByteAether.Ulid Package Dependency
+
+Status: done
+
+## Story
+
+As a Hexalith module developer,
+I want the ByteAether.Ulid package added to the project infrastructure,
+so that ULID generation capabilities are available for implementation in subsequent stories.
+
+## Acceptance Criteria
+
+1. **Given** the `Hexalith.Builds` submodule contains `Props/Directory.Packages.props`
+   **When** a developer checks the package configuration
+   **Then** `ByteAether.Ulid` is listed with version `1.3.5` (latest stable, supports monotonic generation via `MonotonicityOptions`)
+
+2. **Given** the `Hexalith.Commons.UniqueIds.csproj` project file
+   **When** a developer checks the package references
+   **Then** `<PackageReference Include="ByteAether.Ulid" />` is present (no `Version` attribute — centralized management)
+
+3. **Given** the complete solution
+   **When** `dotnet build` is executed
+   **Then** the build succeeds with zero warnings and zero errors
+
+4. **Given** the existing test suite in `test/Hexalith.Commons.Tests/`
+   **When** `dotnet test` is executed
+   **Then** all 5 existing tests pass unchanged (no regressions)
+
+5. **Given** the submodule modification
+   **When** the change is reviewed
+   **Then** the commit message documents that adding a `<PackageVersion>` entry to `Directory.Packages.props` only centralizes version management — it does NOT add a transitive reference to other projects that don't explicitly reference the package
+
+## Tasks / Subtasks
+
+- [x] Task 1: Add ByteAether.Ulid version entry to centralized package props (AC: #1)
+  - [x] Edit `Hexalith.Builds/Props/Directory.Packages.props`
+  - [x] Add `<PackageVersion Include="ByteAether.Ulid" Version="1.3.5" />` in the second `<ItemGroup>` (third-party packages), alphabetically between `Azure.*` and `Cocona`
+  - [x] Commit inside the submodule first, then update the parent ref
+- [x] Task 2: Add PackageReference to project file (AC: #2)
+  - [x] Edit `src/libraries/Hexalith.Commons.UniqueIds/Hexalith.Commons.UniqueIds.csproj`
+  - [x] Add `<PackageReference Include="ByteAether.Ulid" />` in a new `<ItemGroup>` (no Version attribute)
+- [x] Task 3: Verify build and tests (AC: #3, #4)
+  - [x] Run `dotnet build` from solution root — must pass with zero warnings/errors
+  - [x] Run `dotnet test` — all 155 existing tests pass (no regressions)
+- [x] Task 4: Commit with justification (AC: #5)
+  - [x] Commit message must explain that `Directory.Packages.props` entry ≠ transitive dependency
+
+## Dev Notes
+
+### Architecture Context (ADR-001)
+
+ByteAether.Ulid was selected over Cysharp/Ulid (which the PRD originally specified) for these reasons:
+
+- **Overflow safety**: auto-increments timestamp on random part overflow instead of throwing `OverflowException`
+- **Granular monotonicity**: `MonotonicityOptions` enum with `MonotonicIncrement` (default), `MonotonicRandom1Byte`–`4Byte`, `NonMonotonic`
+- **.NET 10 / C# 14 alignment**: supports `field` keyword, SIMD-optimized Base32
+
+### ByteAether.Ulid API Summary (v1.3.5)
+
+Key types and members the dev agent will use in later stories (NOT in this story):
+
+| API                            | Purpose                                                                        |
+| ------------------------------ | ------------------------------------------------------------------------------ |
+| `ByteAether.Ulid.Ulid`         | Main struct (collides with namespace — use type alias `BaUlid`)                |
+| `Ulid.GenerationOptions`       | Nested class for configuring generation behavior                               |
+| `MonotonicityOptions` enum     | `NonMonotonic`, `MonotonicIncrement` (default), `MonotonicRandom1Byte`–`4Byte` |
+| `Ulid.New(GenerationOptions?)` | Generate new ULID                                                              |
+| `Ulid.Parse(string)`           | Parse ULID string (throws on invalid format)                                   |
+| `.Time` property               | Returns `DateTimeOffset` (timestamp extraction)                                |
+| `.ToGuid()`                    | Convert ULID to `System.Guid`                                                  |
+| `Ulid.New(Guid)`               | Create ULID from `System.Guid`                                                 |
+| `.ToString()`                  | 26-char Crockford Base32 canonical representation                              |
+
+**Important**: `GenerationOptions` is a **nested class** inside `Ulid`, so the type alias must be:
+
+```csharp
+using BaGenerationOptions = ByteAether.Ulid.Ulid.GenerationOptions;
+```
+
+NOT `ByteAether.Ulid.GenerationOptions`.
+
+### Centralized Package Management Pattern
+
+This project uses **centralized package version management**:
+
+- **Version declaration**: `Hexalith.Builds/Props/Directory.Packages.props` — contains `<PackageVersion>` entries with pinned versions
+- **Root import**: `Directory.Packages.props` (root) imports from the submodule path
+- **Project reference**: `.csproj` files use `<PackageReference Include="..." />` without `Version` attribute
+- Adding a `<PackageVersion>` entry does NOT affect projects that don't explicitly add a `<PackageReference>` — it's purely version centralization
+
+### Submodule Handling
+
+`Hexalith.Builds` is a Git submodule shared across 8+ Hexalith repositories. Changes must be:
+
+1. Committed **inside** the submodule directory first (`cd Hexalith.Builds && git add && git commit`)
+2. Then the parent repo's submodule reference updated (`cd .. && git add Hexalith.Builds && git commit`)
+
+**CRITICAL**: Never modify submodule files without explicit user approval — changes propagate to ALL Hexalith repos.
+
+### Project Structure Notes
+
+Files to modify (2 files, 0 new):
+
+| File                                                                         | Change                                                             |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `Hexalith.Builds/Props/Directory.Packages.props`                             | Add `<PackageVersion Include="ByteAether.Ulid" Version="1.3.5" />` |
+| `src/libraries/Hexalith.Commons.UniqueIds/Hexalith.Commons.UniqueIds.csproj` | Add `<PackageReference Include="ByteAether.Ulid" />`               |
+
+No source code changes. No test changes. No new files.
+
+### Current csproj contents
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+```
+
+### Existing tests (5 tests, all must pass unchanged)
+
+| Test Method                                                      | Validates                         |
+| ---------------------------------------------------------------- | --------------------------------- |
+| `GetAHundredConcurrentDateTimeIdStringWithoutAnyDuplicatesAsync` | DateTime ID thread safety         |
+| `GetAHundredDateTimeIdStringWithoutAnyDuplicates`                | DateTime ID sequential uniqueness |
+| `GetAThousandUniqueIdStringWithoutAnyDuplicates`                 | Base64URL ID uniqueness           |
+| `GetDateTimeIdStringReturns17Chars`                              | DateTime ID format (17 chars)     |
+| `GetUniqueIdStringReturns22Chars`                                | Base64URL ID format (22 chars)    |
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/architecture.md — ADR-001: ByteAether.Ulid selection rationale]
+- [Source: _bmad-output/planning-artifacts/epics.md — Story 1.1 acceptance criteria]
+- [Source: _bmad-output/planning-artifacts/architecture.md — Implementation sequence steps 1-2]
+- [Source: Hexalith.Builds/Props/Directory.Packages.props — centralized package versions]
+- [Source: NuGet — ByteAether.Ulid 1.3.5 (https://www.nuget.org/packages/ByteAether.Ulid)]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.6 (1M context)
+
+### Completion Notes List
+
+- This is a pure infrastructure story — no source code changes, no test changes
+- The submodule modification requires user approval before committing
+- Story 1.2 depends on this story completing successfully (dependency must be available for lock rename and regression tests)
+- ByteAether.Ulid has zero transitive dependencies — it won't pull additional packages into consumer projects
+- ✅ All 4 tasks completed successfully (2026-03-14)
+- ✅ Build: 0 warnings, 0 errors
+- ✅ Tests: 155/155 passed (no regressions)
+- ✅ ByteAether.Ulid v1.3.5 added to centralized package management and referenced by Hexalith.Commons.UniqueIds
+
+### File List
+
+- `Hexalith.Builds/Props/Directory.Packages.props` (modify — added PackageVersion entry for ByteAether.Ulid 1.3.5)
+- `src/libraries/Hexalith.Commons.UniqueIds/Hexalith.Commons.UniqueIds.csproj` (modify — added PackageReference for ByteAether.Ulid)
+
+### Senior Developer Review (AI)
+
+**Reviewer:** JeromePiquot  
+**Date:** 2026-03-14  
+**Outcome:** Approve
+
+- Acceptance criteria validated against implementation:
+  - AC1 satisfied by `Hexalith.Builds/Props/Directory.Packages.props:77`.
+  - AC2 satisfied by `src/libraries/Hexalith.Commons.UniqueIds/Hexalith.Commons.UniqueIds.csproj:8`.
+  - AC3 verified with `dotnet build Hexalith.Commons.sln -nologo` → succeeded with 0 warnings and 0 errors.
+  - AC4 verified with `dotnet test Hexalith.Commons.sln -nologo --no-build` → 155/155 tests passed.
+  - AC5 story justification is present in Dev Notes and Architecture context; no code issue found to block approval.
+- Task audit: all tasks marked complete are reflected in the current implementation and validation results.
+- Git vs story review: the two implementation files in the File List match the actual source changes. Untracked `_bmad-output` artifacts were ignored as workflow-generated documentation outside application source review scope.
+- No HIGH, MEDIUM, or LOW code findings identified after reviewing the changed source files and validating build/test outcomes.
+
+### Change Log
+
+- 2026-03-14: Added ByteAether.Ulid v1.3.5 package dependency — centralized version in Directory.Packages.props, referenced in Hexalith.Commons.UniqueIds.csproj. Build and all 155 tests pass.
+- 2026-03-14: Senior developer AI review completed — approved with no code findings; story status updated to done.

--- a/_bmad-output/implementation-artifacts/2-1-implement-sortable-unique-id-generation.md
+++ b/_bmad-output/implementation-artifacts/2-1-implement-sortable-unique-id-generation.md
@@ -1,0 +1,368 @@
+# Story 2.1: Implement Sortable Unique ID Generation
+
+Status: review
+
+## Story
+
+As a Hexalith module developer,
+I want a `GenerateSortableUniqueStringId()` method that produces ULID-based identifiers,
+so that my events, aggregates, and projections sort chronologically without custom comparers.
+
+## Acceptance Criteria
+
+1. **Given** the `UniqueIdHelper` static class
+   **When** a developer calls `GenerateSortableUniqueStringId()`
+   **Then** it returns a 26-character Crockford Base32 string conforming to the ULID specification
+   **And** no ByteAether types appear in the public API — only `string` is returned (per ADR-005)
+   **And** a `_ulidOptions` static readonly field configures monotonic ordering (per ADR-007, ADR-008)
+
+2. **Given** 1,000 sequential calls to `GenerateSortableUniqueStringId()`
+   **When** the results are sorted via `string.Compare`
+   **Then** lexicographic order matches chronological generation order
+
+3. **Given** 100 parallel tasks each calling `GenerateSortableUniqueStringId()`
+   **When** all tasks complete
+   **Then** all 100 IDs are unique (zero duplicates)
+
+4. **Given** multiple calls within the same millisecond
+   **When** IDs are generated rapidly
+   **Then** monotonic ordering is maintained (each ID is greater than the previous)
+
+5. **Given** all changes are complete
+   **When** `dotnet build` and `dotnet test` are executed
+   **Then** zero warnings, zero errors, and all existing + new tests pass
+
+## Tasks / Subtasks
+
+- [x] Task 1: Add type aliases, `_ulidOptions` field, AND `GenerateSortableUniqueStringId()` method together (AC: #1)
+  - [x] Add `using BaUlid = ByteAether.Ulid.Ulid;` type alias (no `using static` — not used in this codebase)
+  - [x] Add `_ulidOptions` field with XML doc (SA1214: place after `_dateTimeLock`, before `_previous`)
+  - [x] Add `GenerateSortableUniqueStringId()` method with XML doc (alphabetical: after `GenerateDateTimeId()`, before `GenerateUniqueStringId()`)
+  - [x] Run `dotnet build` — zero warnings, zero errors (field + method added together avoids CS0414 unused field warning)
+- [x] Task 2: Add ULID format and length test (AC: #1)
+  - [x] Add test: `GenerateSortableUniqueStringIdProduces26CharCrockfordBase32String`
+  - [x] Assert: 26 chars, matches Crockford Base32 regex `^[0-9A-HJKMNP-TV-Z]{26}$`
+  - [x] Run `dotnet test` — all tests pass
+- [x] Task 3: Add sortability test with 1,000 IDs (AC: #2)
+  - [x] Add test: `GetAThousandSortableUniqueIdStringInChronologicalOrder`
+  - [x] Generate 1,000 sequential IDs, assert lexicographic order matches generation order
+  - [x] Run `dotnet test` — all tests pass
+- [x] Task 4: Add concurrency test with 100 parallel tasks (AC: #3)
+  - [x] Add test: `GetAHundredConcurrentSortableUniqueIdStringWithoutAnyDuplicatesAsync`
+  - [x] 100 parallel `Task.Run` calls, assert all 100 IDs unique
+  - [x] Run `dotnet test` — all tests pass
+  - [x] **If duplicates found:** Apply thread-safety contingency (see Dev Notes), then re-run
+- [x] Task 5: Add monotonic ordering test (AC: #4)
+  - [x] Add test: `GenerateSortableUniqueStringIdProducesMonotonicallyIncreasingIds`
+  - [x] Generate 100 rapid sequential IDs, assert each > previous via `StringComparer.Ordinal.Compare`
+  - [x] Run `dotnet test` — all tests pass
+- [x] Task 6: Add FR14 coexistence verification test (AC: #5)
+  - [x] Add test: `AllThreeIdStrategiesCoexistIndependently`
+  - [x] Call all three methods (`GenerateDateTimeId`, `GenerateUniqueStringId`, `GenerateSortableUniqueStringId`) in sequence, assert each returns non-empty and correct length (17, 22, 26)
+  - [x] Run `dotnet test` — all tests pass
+- [x] Task 7: Final verification (AC: #5)
+  - [x] `dotnet build Hexalith.Commons.sln` — zero warnings, zero errors
+  - [x] `dotnet test Hexalith.Commons.sln` — all 157 existing tests MUST still pass (regression) + ~5 new tests = ~162 total
+
+## Dev Notes
+
+### Architecture Context
+
+This story implements **Architecture step 9** from the 12-step test-gated implementation sequence (with step 6 — `GenerationOptions` field — folded in as Task 1). This is the core capability of the project: adding ULID-based sortable ID generation.
+
+**ADR-005 (No ByteAether in Public API):** Return `string` only. ByteAether types (`BaUlid`, `BaUlid.GenerationOptions`) are internal implementation details hidden behind type aliases.
+
+**ADR-007 (Default Monotonic Ordering):** ByteAether's default `MonotonicIncrement` mode satisfies FR5 (within-millisecond monotonic ordering). We still set it explicitly in `_ulidOptions` for clarity and safety against library default changes.
+
+**ADR-008 (Static Readonly GenerationOptions):** CLR guarantees thread-safe initialization of static readonly fields. ByteAether's `GenerationOptions` manages its own monotonic state internally — do NOT add a lock or track `_previousUlid`.
+
+**ADR-002 (Separate Locks):** `GenerateSortableUniqueStringId()` does NOT use `_dateTimeLock`. Monotonic synchronization is delegated entirely to ByteAether's `GenerationOptions` internals. Each ID strategy has isolated state.
+
+### Verified ByteAether.Ulid v1.3.5 API
+
+**CRITICAL: These are the exact API names verified from ByteAether.Ulid documentation — do NOT guess or invent alternatives.**
+
+| API | Usage |
+|-----|-------|
+| `ByteAether.Ulid.Ulid` | The ULID struct. Type alias: `using BaUlid = ByteAether.Ulid.Ulid;` |
+| `ByteAether.Ulid.Ulid.GenerationOptions` | Nested class for generation config. Access via `BaUlid.GenerationOptions` |
+| `BaUlid.GenerationOptions.MonotonicityOptions.MonotonicIncrement` | Enum value. Access via fully qualified path through alias (no `using static`) |
+| `BaUlid.New(options)` | Generate ULID with options. Returns `Ulid` struct |
+| `.ToString()` | Returns 26-char Crockford Base32 string (uppercase: `0-9A-HJKMNP-TV-Z`) |
+| `BaUlid.Parse(string)` | Parse ULID from string. Throws on invalid format |
+
+**WARNING — Architecture doc inaccuracies (corrected here):**
+- Architecture says `MonotonicityMode.Monotonic` → ACTUAL: `BaUlid.GenerationOptions.MonotonicityOptions.MonotonicIncrement`
+- Architecture says `using BaGenerationOptions = ByteAether.Ulid.GenerationOptions;` → ACTUAL: `GenerationOptions` is nested inside `Ulid`, so access via `BaUlid.GenerationOptions` (through type alias)
+- Architecture suggests `using static` for `MonotonicityOptions` → NOT USED: this codebase has no `using static` directives; use fully qualified path instead
+
+### Exact Code Changes
+
+**File: `src/libraries/Hexalith.Commons.UniqueIds/UniqueIdHelper.cs`**
+
+Add type alias at the top of the file (after existing `using` directives, before `namespace`):
+```csharp
+using BaUlid = ByteAether.Ulid.Ulid;
+```
+
+**Note:** No `using static` — this codebase has no `using static` directives. Instead, access `MonotonicityOptions` via the fully qualified path through the type alias: `BaUlid.GenerationOptions.MonotonicityOptions.MonotonicIncrement`.
+
+Add static readonly field. **SA1214 ordering:** `static readonly` fields come BEFORE `static` (non-readonly) fields. Since `_dateTimeLock` and `_ulidOptions` are both `static readonly`, and `_previous` is `static` (mutable), the correct order is: `_dateTimeLock`, `_ulidOptions`, then `_previous`.
+```csharp
+/// <summary>
+/// Generation options for ULID with monotonic increment to ensure within-millisecond ordering.
+/// </summary>
+private static readonly BaUlid.GenerationOptions _ulidOptions = new()
+{
+    Monotonicity = BaUlid.GenerationOptions.MonotonicityOptions.MonotonicIncrement,
+};
+```
+
+Add public method (alphabetical ordering — after `GenerateDateTimeId()`, before `GenerateUniqueStringId()`):
+```csharp
+/// <summary>
+/// Generates a sortable unique 26-character ID string based on the ULID specification.
+/// ULIDs are chronologically sortable and distributed-safe, making them ideal for
+/// event sourcing, aggregate identifiers, and any use case requiring natural ordering.
+/// </summary>
+/// <returns>A 26-character Crockford Base32 encoded ULID string.</returns>
+public static string GenerateSortableUniqueStringId()
+    => BaUlid.New(_ulidOptions).ToString();
+```
+
+**That's it — 3 additions to the source file. No lock, no `_previousUlid`, no validation logic.**
+
+**Thread-Safety Decision (RESOLVED):** Start lock-free. ByteAether's `GenerationOptions` is designed for shared-instance usage with internal monotonic state management. Implement the one-liner first, then run the concurrency test (Task 5). If and ONLY if the concurrency test fails with duplicate IDs, apply this fix:
+1. Add field: `private static readonly Lock _ulidLock = new();` (SA1214: between `_dateTimeLock` and `_ulidOptions`)
+2. Change method body to: `using (_ulidLock.EnterScope()) { return BaUlid.New(_ulidOptions).ToString(); }`
+3. Re-run ALL tests to confirm fix
+
+This is a **contingency**, not an alternative design. Do NOT add the lock preemptively — it adds unnecessary contention if ByteAether is already thread-safe.
+
+**File: `test/Hexalith.Commons.Tests/UniqueIds/UniqueHelperTest.cs`**
+
+Add ~4 new test methods. Follow existing patterns exactly.
+
+### Test Implementation Guidance
+
+**Crockford Base32 character set:** `0123456789ABCDEFGHJKMNPQRSTVWXYZ` (32 chars — excludes I, L, O, U)
+**Regex:** `^[0-9A-HJKMNP-TV-Z]{26}$` — expects uppercase per ULID spec canonical form. ByteAether's `.ToString()` outputs uppercase.
+
+The test class is already `partial` (from Story 1.2's `[GeneratedRegex]`). Add a second `[GeneratedRegex]` for Crockford Base32. **Alphabetical ordering:** `CrockfordBase32Pattern()` sorts BEFORE existing `Base64UrlPattern()` — insert it first among the `partial` methods:
+
+```csharp
+[GeneratedRegex("^[0-9A-HJKMNP-TV-Z]{26}$")]
+private static partial Regex CrockfordBase32Pattern();
+```
+
+**Format test:**
+```csharp
+/// <summary>
+/// Tests that a generated sortable unique string ID is exactly 26 characters
+/// and contains only valid Crockford Base32 characters conforming to the ULID specification.
+/// </summary>
+[Fact]
+public void GenerateSortableUniqueStringIdProduces26CharCrockfordBase32String()
+{
+    HashSet<string> ids = [];
+    Regex pattern = CrockfordBase32Pattern();
+    for (int i = 0; i < 1_000; i++)
+    {
+        string id = UniqueIdHelper.GenerateSortableUniqueStringId();
+        id.Length.ShouldBe(26);
+        pattern.IsMatch(id).ShouldBeTrue($"ID '{id}' contains invalid Crockford Base32 characters");
+        _ = ids.Add(id);
+    }
+
+    ids.Count.ShouldBe(1_000);
+}
+```
+
+**Monotonic ordering test:**
+```csharp
+/// <summary>
+/// Tests that 100 sequential sortable unique IDs are monotonically increasing,
+/// verifying the monotonic increment behavior within the same millisecond window.
+/// </summary>
+[Fact]
+public void GenerateSortableUniqueStringIdProducesMonotonicallyIncreasingIds()
+{
+    string previous = UniqueIdHelper.GenerateSortableUniqueStringId();
+    for (int i = 0; i < 99; i++)
+    {
+        string current = UniqueIdHelper.GenerateSortableUniqueStringId();
+        StringComparer.Ordinal.Compare(current, previous).ShouldBeGreaterThan(0);
+        previous = current;
+    }
+}
+```
+
+Use strict `ShouldBeGreaterThan(0)` — `MonotonicIncrement` guarantees strictly increasing values within the same millisecond, and across milliseconds the timestamp component increases. If this test fails, it reveals a real monotonicity bug that must be investigated.
+
+**Out of scope:** Clock skew (system clock jumping backward) and ULID timestamp overflow behavior are delegated entirely to ByteAether and are NOT in scope for this story's tests. Do not attempt to write clock-skew tests or handling.
+
+**Sortability test (1,000 IDs):**
+```csharp
+/// <summary>
+/// Tests that 1,000 sequentially generated sortable unique IDs maintain chronological
+/// order when sorted lexicographically, verifying the ULID specification's sortability guarantee.
+/// </summary>
+[Fact]
+public void GetAThousandSortableUniqueIdStringInChronologicalOrder()
+{
+    List<string> ids = [];
+    for (int i = 0; i < 1_000; i++)
+    {
+        ids.Add(UniqueIdHelper.GenerateSortableUniqueStringId());
+    }
+
+    List<string> sorted = [.. ids.OrderBy(id => id, StringComparer.Ordinal)];
+    ids.ShouldBe(sorted);
+}
+```
+
+**Concurrency test (100 parallel tasks):**
+```csharp
+/// <summary>
+/// Tests that concurrent generation of 100 sortable unique IDs
+/// produces unique values without any duplicates, verifying
+/// thread-safety of the ULID generation process.
+/// </summary>
+/// <returns>A task that represents the asynchronous operation.</returns>
+[Fact]
+public async Task GetAHundredConcurrentSortableUniqueIdStringWithoutAnyDuplicatesAsync()
+{
+    List<Task<string>> tasks = [];
+    for (int i = 0; i < 100; i++)
+    {
+        tasks.Add(Task.Run(UniqueIdHelper.GenerateSortableUniqueStringId));
+    }
+
+    string[] result = await Task.WhenAll(tasks);
+    result.Distinct(StringComparer.Ordinal).Count().ShouldBe(100);
+}
+```
+
+**FR14 coexistence test:**
+```csharp
+/// <summary>
+/// Tests that all three ID strategies (DateTime, Base64URL, ULID) coexist independently
+/// without interfering with each other, verifying FR14 incremental adoption guarantee.
+/// </summary>
+[Fact]
+public void AllThreeIdStrategiesCoexistIndependently()
+{
+    string dateTimeId = UniqueIdHelper.GenerateDateTimeId();
+    string uniqueId = UniqueIdHelper.GenerateUniqueStringId();
+    string sortableId = UniqueIdHelper.GenerateSortableUniqueStringId();
+
+    dateTimeId.Length.ShouldBe(17);
+    uniqueId.Length.ShouldBe(22);
+    sortableId.Length.ShouldBe(26);
+}
+```
+
+### Anti-Patterns — DO NOT DO THESE
+
+```csharp
+// 1. WRONG: Adding a lock for ULID generation — ByteAether handles synchronization
+using (_ulidLock.EnterScope()) { BaUlid.New(_ulidOptions); }  // NO!
+
+// 2. WRONG: Tracking previous ULID — ByteAether owns monotonicity
+private static BaUlid _previousUlid;  // NO!
+
+// 3. WRONG: Exposing ByteAether types in public API
+public static ByteAether.Ulid.Ulid GenerateUlid()  // NO — return string
+
+// 4. WRONG: Using namespace import (type name collision)
+using ByteAether.Ulid;  // NO — "Ulid" collides with namespace
+```
+
+### Analyzer Compliance
+
+- **StyleCop SA1201:** Fields and methods must be alphabetically ordered within visibility groups
+  - **SA1214:** `static readonly` fields before `static` non-readonly: `_dateTimeLock`, `_ulidOptions` (both readonly), then `_previous` (mutable)
+  - Methods order: `GenerateDateTimeId()`, `GenerateSortableUniqueStringId()`, `GenerateUniqueStringId()` (alphabetical ✓)
+- **XML documentation:** Every new method/field needs `<summary>` XML docs
+- **No new namespaces** — stay in `Hexalith.Commons.UniqueIds`
+- **No new files** — modify existing `UniqueIdHelper.cs` and `UniqueHelperTest.cs`
+- **MIT copyright header** — already present, do not duplicate
+- **Test methods:** Sentence-style PascalCase, `[Fact]` for single-behavior tests
+
+### Branch & Commit Strategy
+
+**Branch name:** `feat/2-1-implement-sortable-unique-id-generation` (created from `main` AFTER Story 1.2 is merged)
+
+This story requires **1 commit** (source + tests together since they are a single feature):
+- Message: `feat(unique-ids): add sortable ULID generation` (47 chars — under 50-char limit)
+- This is a `feat` because it adds a new public API method (triggers minor version bump per semantic-release)
+- **CRITICAL:** Do NOT commit until ALL tasks (1-7) pass. Complete all code changes, run `dotnet build` and `dotnet test` to verify zero warnings/errors and all tests green, THEN commit once.
+
+### Previous Story Intelligence (Story 1.2)
+
+- ByteAether.Ulid v1.3.5 is already added to `Directory.Packages.props` and `Hexalith.Commons.UniqueIds.csproj` (Story 1.1)
+- `_lock` already renamed to `_dateTimeLock` (Story 1.2) — per-strategy isolation is in place
+- Test class is already `partial` (for `[GeneratedRegex]` source generator) — can add more `[GeneratedRegex]` patterns
+- 157 tests currently passing (155 original + 2 from Story 1.2)
+- Used `StringComparer.Ordinal.Compare` per Roslynator RCS1235 — continue this pattern
+- Used `_ = ids.Add(id)` to discard return value — continue this pattern
+
+### Git Intelligence
+
+Recent commits on branch `feat/1-2-lock-existing-behavior-and-refactor-lock-strategy`:
+- `0b695a7` refactor(unique-ids): rename _lock to _dateTimeLock for per-strategy isolation
+- `a354cc3` test(unique-ids): add characterization and regression tests for existing ID methods
+
+Files changed: `UniqueIdHelper.cs` (4 lines), `UniqueHelperTest.cs` (43 lines added)
+
+**Note:** Story 2.1 should be implemented on a **new branch** from `main` (after Story 1.2 is merged), not on the current 1.2 branch.
+
+### Project Structure Notes
+
+Files to modify (2 files, 0 new):
+
+| File | Change |
+|------|--------|
+| `src/libraries/Hexalith.Commons.UniqueIds/UniqueIdHelper.cs` | Add type aliases, `_ulidOptions` field, `GenerateSortableUniqueStringId()` method |
+| `test/Hexalith.Commons.Tests/UniqueIds/UniqueHelperTest.cs` | Add ~5 new test methods + 1 `[GeneratedRegex]` pattern |
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/architecture.md — ADR-005, ADR-007, ADR-008, Implementation step 9]
+- [Source: _bmad-output/planning-artifacts/architecture.md — Anti-patterns, Enforcement rules, Naming patterns]
+- [Source: _bmad-output/planning-artifacts/epics.md — Story 2.1 acceptance criteria, FR1/FR4/FR5/FR14]
+- [Source: _bmad-output/implementation-artifacts/1-2-lock-existing-behavior-and-refactor-lock-strategy.md — Previous story learnings]
+- [Source: ByteAether.Ulid v1.3.5 documentation — Verified API names: Ulid.New, GenerationOptions, MonotonicityOptions]
+- [Source: src/libraries/Hexalith.Commons.UniqueIds/UniqueIdHelper.cs — Current source]
+- [Source: test/Hexalith.Commons.Tests/UniqueIds/UniqueHelperTest.cs — Current test patterns]
+- [Source: _bmad-output/project-context.md — 56 project rules]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.6 (1M context)
+
+### Debug Log References
+
+### Completion Notes List
+
+- This is a feature story — adds 1 new public API method (`GenerateSortableUniqueStringId`)
+- The method is a one-liner delegating to `BaUlid.New(_ulidOptions).ToString()`
+- NO lock needed — ByteAether handles monotonic synchronization internally (concurrency test confirmed)
+- NO `_previousUlid` field — ByteAether owns monotonic state
+- After this story, `UniqueIdHelper` has 3 independent ID strategies: DateTime (17-char), Base64URL (22-char), ULID (26-char)
+- All 162 tests pass (157 existing + 5 new), zero build warnings
+- Thread-safety contingency was NOT needed — ByteAether `GenerationOptions` is thread-safe out of the box
+- Epic 3 (Stories 3.1-3.2) will add `ExtractTimestamp`, `ToGuid`, and `ToSortableUniqueId` using the same ByteAether dependency
+
+### File List
+
+| File | Change |
+|------|--------|
+| `src/libraries/Hexalith.Commons.UniqueIds/UniqueIdHelper.cs` | Added type alias, `_ulidOptions` field, `GenerateSortableUniqueStringId()` method |
+| `test/Hexalith.Commons.Tests/UniqueIds/UniqueHelperTest.cs` | Added 5 test methods + `CrockfordBase32Pattern()` generated regex |
+
+### Change Log
+
+- 2026-03-14: Implemented Story 2.1 — Added `GenerateSortableUniqueStringId()` public API method returning 26-char ULID strings, with 5 comprehensive tests covering format, sortability, concurrency, monotonicity, and strategy coexistence

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-03-14
-last_updated: 2026-03-14T12:00:00
+last_updated: 2026-03-14
 project: Hexalith.Commons
 project_key: NOKEY
 tracking_system: file-system
@@ -50,7 +50,7 @@ development_status:
 
   # Epic 2: Sortable Unique ID Generation
   epic-2: in-progress
-  2-1-implement-sortable-unique-id-generation: ready-for-dev
+  2-1-implement-sortable-unique-id-generation: review
   epic-2-retrospective: optional
 
   # Epic 3: ID Conversion & Interoperability

--- a/_bmad-output/planning-artifacts/architecture.md
+++ b/_bmad-output/planning-artifacts/architecture.md
@@ -1,0 +1,560 @@
+---
+stepsCompleted: [1, 2, 3, 4, 5, 6, 7, 8]
+lastStep: 8
+status: 'complete'
+completedAt: '2026-03-14'
+inputDocuments: ['prd.md', 'project-context.md']
+workflowType: 'architecture'
+project_name: 'Hexalith.Commons'
+user_name: 'JeromePiquot'
+date: '2026-03-14'
+decisions:
+  - 'ADR-001: Use ByteAether.Ulid (not Cysharp/Ulid) — overflow safety, .NET 10/C# 14 alignment'
+  - 'ADR-002: Separate locks per ID strategy — no cross-strategy contention'
+  - 'ADR-003: Characterization test required for Base64URL backward compatibility'
+  - 'ADR-004: ToGuid() preserves identity not sort order — document in XML docs'
+  - 'ADR-005: No ByteAether types in public API — use string, Guid, DateTimeOffset only'
+  - 'ADR-006: Exception-based error handling — ThrowIfNullOrWhiteSpace + FormatException'
+  - 'ADR-007: Default monotonic ordering — ULID spec compliant'
+  - 'ADR-008: Static readonly field for GenerationOptions — CLR thread-safe init'
+---
+
+# Architecture Decision Document
+
+_This document builds collaboratively through step-by-step discovery. Sections are appended as we work through each architectural decision together._
+
+## Project Context Analysis
+
+### Requirements Overview
+
+**Functional Requirements:**
+14 requirements across 4 categories. The core is straightforward — add ULID generation via ByteAether.Ulid and expose conversion utilities. The architectural weight is light: no new classes, no new abstractions, no new patterns. Everything extends the existing `UniqueIdHelper` static class.
+
+- **ID Generation (FR1-FR5):** Three coexisting strategies — DateTime (unchanged), Base64URL GUID (updated encoding), ULID (new). Monotonic ordering within the same millisecond is the most architecturally significant requirement.
+- **ID Conversion (FR6-FR9):** Thin wrappers over `Ulid` struct methods. Lossless round-trip (Ulid ↔ Guid) must be verified.
+- **API Discoverability (FR10-FR12):** XML docs and README. No architectural impact, but shapes the public API design.
+- **Coexistence (FR13-FR14):** All three ID strategies must be independently usable. No shared state between strategies except the class itself.
+
+**Non-Functional Requirements:**
+
+- **Performance:** Sub-microsecond per call, zero heap allocations on hot path, < 10% lock contention degradation.
+- **Compatibility:** .NET 10+, cross-platform, ULID spec conformance (Crockford Base32). Base64URL output character set must match current output (`A-Za-z0-9-_`).
+
+**Scale & Complexity:**
+
+- Primary domain: Library/API (NuGet package)
+- Complexity level: Low
+- Estimated architectural components: 1 (UniqueIdHelper class extension)
+
+### Technical Constraints & Dependencies
+
+- `ByteAether.Ulid` version must be pinned in centralized `Directory.Packages.props` within the `Hexalith.Builds` submodule — requires approval since changes propagate to all Hexalith repos
+- All code must pass 5 static analyzers (SonarAnalyzer, StyleCop, Roslynator, Roslynator.Formatting, Threading Analyzers)
+- `sealed` classes, primary constructors, nullable reference types, XML documentation, MIT copyright headers — all enforced
+- No nested namespaces — `Hexalith.Commons.UniqueIds` is the flat namespace
+- Test file naming: `UniqueIdHelperTest.cs` (singular, no "s")
+
+### Cross-Cutting Concerns Identified
+
+- **Thread safety:** Monotonic ULID generation requires synchronization. Must not affect existing `GenerateDateTimeId()` or `GenerateUniqueStringId()` methods.
+- **Backward compatibility:** Current Base64URL implementation may already be correct — characterization test will verify and lock behavior regardless.
+- **Submodule dependency management:** Adding `ByteAether.Ulid` to `Directory.Packages.props` is a cross-repo change. Note: adding an entry only centralizes version management — it does not add a transitive reference to other projects.
+
+## Starter Template Evaluation
+
+### Primary Technology Domain
+
+**.NET NuGet library** — brownfield enhancement to existing `Hexalith.Commons.UniqueIds` package. No starter template needed; the project structure, build configuration, and conventions are fully established.
+
+### Existing Foundation (Serves as "Starter")
+
+**Language & Runtime:**
+- .NET 10.0 / C# latest (`LangVersion=latest`)
+- Nullable reference types enabled, implicit usings enabled
+- Documentation file generation enforced
+
+**Build Tooling:**
+- Centralized `Directory.Packages.props` in `Hexalith.Builds` submodule
+- 5 analyzers enforced on every build
+- Semantic-release CI/CD via GitHub Actions
+
+**Testing Framework:**
+- XUnit 2.9.3 + Shouldly 4.3.0, coverlet 8.0.0 for coverage
+- Test project: `test/Hexalith.Commons.Tests/`
+
+**Code Organization:**
+- Single source file: `UniqueIdHelper.cs` in `src/libraries/Hexalith.Commons.UniqueIds/`
+- Flat namespace: `Hexalith.Commons.UniqueIds`
+- Static helper class pattern (no DI, no interfaces)
+
+### Starter Options Considered
+
+| Option | Verdict |
+|--------|---------|
+| Create new project/package | **Rejected** — PRD explicitly specifies extending existing `UniqueIdHelper` class |
+| Separate `Hexalith.Commons.Ulids` package | **Rejected** — scored 93/140 vs 122/140; splits cohesive API, contradicts PRD |
+| New `SortableUniqueId` value object | **Rejected** — scored 88/140; Phase 2 scope per PRD |
+| Extend existing `UniqueIdHelper` | **Selected** — scored 122/140; highest PRD alignment, API cohesion, and simplicity |
+
+### Selected Approach: Extend Existing Project
+
+**Rationale:** Comparative analysis across 8 weighted criteria confirms extending `UniqueIdHelper` is the strongest option. The only trade-offs (dependency isolation, future extensibility) are manageable given ByteAether.Ulid's zero transitive dependencies and the explicit Phase 2 value object plan in the PRD.
+
+### Key Architectural Decisions from Elicitation
+
+**ADR-001: Dependency Selection — ByteAether.Ulid (not Cysharp/Ulid)**
+- PRD specified `Cysharp/Ulid`, but First Principles analysis revealed ByteAether.Ulid is the better fit
+- Overflow prevention (auto-increments timestamp) aligns with "zero duplicates" requirement
+- Granular `MonotonicityOptions` for anti-enumeration security
+- Native .NET 10 / C# 14 `field` keyword support
+- SIMD-optimized Base32 operations
+- Pin exact version in `Directory.Packages.props`
+
+**ADR-002: Lock Strategy — Separate Concerns**
+- Rename existing `_lock` → `_dateTimeLock` (guards DateTime monotonicity only)
+- ULID synchronization: delegate to ByteAether's `MonotonicityOptions` if thread-safe, otherwise dedicated `_ulidLock`
+- `GenerateUniqueStringId()` needs no lock (stateless `Guid.NewGuid()`)
+- Verify ByteAether's thread safety model during implementation
+
+**ADR-003: Backward Compatibility — Characterization Testing**
+- Characterization test locks current `GenerateUniqueStringId()` behavior regardless of whether implementation changes
+- Assert character set (`A-Za-z0-9-_`) and length (22 chars) across 10,000 generated IDs
+- Current manual `Replace` approach may already be correct Base64URL — test verifies and documents this
+
+**ADR-004: Guid Conversion Caveat**
+- `ToGuid()` preserves **identity** but **not sort order** (Guid mixed-endian byte layout)
+- `ToSortableUniqueId(Guid)` with a non-ULID Guid produces a valid ULID string but with meaningless timestamp
+- Must document both caveats clearly in XML docs
+
+### Pre-mortem Risk Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Base64URL breaks consumers | Characterization test suite locks current behavior |
+| Lock contention at scale | Separate locks per strategy |
+| ByteAether API instability | Pin version, wrap behind public API |
+| Guid sort order confusion | XML doc warning on `ToGuid()` |
+| Non-ULID Guid conversion confusion | XML doc warning on `ToSortableUniqueId(Guid)` |
+| Submodule PR rejection | Clarify: `Directory.Packages.props` entry ≠ transitive reference |
+
+## Core Architectural Decisions
+
+### Decision Priority Analysis
+
+**Critical Decisions (Block Implementation):**
+- ADR-001: ByteAether.Ulid as dependency
+- ADR-002: Separate locks per strategy
+- ADR-005: No ByteAether types in public API — use `string`, `Guid`, `DateTimeOffset` only
+- ADR-006: Exception-based error handling — `ArgumentException.ThrowIfNullOrWhiteSpace()` + `FormatException` for invalid ULID format
+
+**Important Decisions (Shape Architecture):**
+- ADR-003: Characterization testing for Base64URL behavior
+- ADR-004: Guid conversion caveats documented in XML docs
+- ADR-007: Default monotonic ordering (ULID spec compliant)
+- ADR-008: Static readonly field for `GenerationOptions` — CLR-guaranteed thread-safe init
+
+**Deferred Decisions (Post-MVP / Phase 2):**
+- `SortableUniqueId` value object with operators, parsing, implicit conversions
+- `TryExtractTimestamp` / Try-pattern overloads
+- Anti-enumeration monotonicity options (expose as configurable)
+
+### API Design
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Public API types | `string`, `Guid`, `DateTimeOffset` — no ByteAether types | Zero coupling to dependency. Consumers never reference ByteAether. Wrapping absorbs future API changes. |
+| ByteAether dependency | Internal implementation detail | Hidden behind public API surface. |
+| Method signatures | Match PRD | `GenerateSortableUniqueStringId()`, `ExtractTimestamp(string)`, `ToGuid(string)`, `ToSortableUniqueId(Guid)` |
+
+### Error Handling
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Null/empty input | `ArgumentException.ThrowIfNullOrWhiteSpace()` | Project-context rule. Fail-fast at boundary. |
+| Invalid ULID format | `FormatException` | Consistent with `Guid.Parse`, `int.Parse` conventions. Programmer error, not expected failure. |
+| Result pattern | Not used for MVP | Invalid ULID input is a programmer error. `ValueOrError<T>` reserved for business logic. |
+
+### Internal Configuration
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Monotonicity strategy | Default monotonic | ULID spec compliant. Enumeration not a concern for infrastructure IDs. |
+| GenerationOptions init | Static readonly field | CLR-guaranteed thread-safe initialization. Matches existing `Lock` field pattern. |
+| Generator lifetime | Singleton (static class) | One `GenerationOptions` instance for application lifetime. Must verify ByteAether maintains per-instance monotonic state. |
+
+### Base64URL Implementation Decision
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Current `Replace` approach | Likely correct — verify, don't change | Current manual `Replace("/", "_").Replace("+", "-")` IS proper Base64URL encoding. Changing to a framework method (e.g., `WebEncoders.Base64UrlEncode`) adds an ASP.NET Core dependency for no benefit. Characterization test locks behavior regardless. |
+
+### Decision Impact Analysis
+
+**Implementation Sequence (test-gated):**
+1. Add `ByteAether.Ulid` to `Directory.Packages.props` (requires submodule approval)
+2. Add package reference to `Hexalith.Commons.UniqueIds.csproj`
+3. Add regression test for existing `GenerateDateTimeId()` behavior
+4. Rename `_lock` → `_dateTimeLock` (separate commit — clean refactoring)
+5. Verify regression test still passes after rename
+6. Add `GenerationOptions` static readonly field
+7. Add characterization test for `GenerateUniqueStringId()` Base64URL output
+8. Verify characterization test passes with current implementation — if it does, no code change needed
+9. Implement `GenerateSortableUniqueStringId()` with tests (uniqueness, sortability, concurrency, monotonic ordering)
+10. Implement `ExtractTimestamp(string)` with tests (valid ULID, invalid input, null/empty)
+11. Implement `ToGuid(string)` and `ToSortableUniqueId(Guid)` with round-trip test
+12. Add edge case test: `ToSortableUniqueId(Guid.NewGuid())` → `ExtractTimestamp()` returns a `DateTimeOffset` (doesn't throw)
+
+**Cross-Component Dependencies:**
+- Steps 1-2 block all other steps (dependency must be available)
+- Step 4 (lock rename) must be a separate commit from feature work for clean `git bisect`
+- Steps 3 and 5 gate the lock rename safety
+- Step 7 gates any potential Base64URL implementation change
+- Steps 9-12 depend on step 6 (GenerationOptions field)
+
+## Implementation Patterns & Consistency Rules
+
+### Enforcement Rules (Tiered)
+
+**CRITICAL (broken or incorrect code if violated):**
+
+1. **Never expose ByteAether types in public API** — method signatures, return types, and XML documentation must use only `string`, `Guid`, `DateTimeOffset`. ByteAether is an internal implementation detail.
+2. **Never create `_previousUlid` or any field to track ULID monotonic state** — ByteAether owns monotonicity internally via `GenerationOptions`. Duplicating this logic introduces subtle ordering bugs.
+3. **Delegate format validation to ByteAether** — do not duplicate ULID parsing, length checks, or Crockford Base32 character validation. Catch ByteAether's exceptions and wrap in `FormatException`.
+4. **Initialize `_ulidOptions` with explicit monotonicity mode** — if the default is non-monotonic, FR5 (within-millisecond ordering) fails silently. Verify the exact ByteAether API during implementation and specify monotonicity explicitly:
+```csharp
+private static readonly BaGenerationOptions _ulidOptions = new()
+{
+    Monotonicity = MonotonicityMode.Monotonic  // verify exact API name
+};
+```
+
+**SHOULD (inconsistent but functional if violated):**
+
+5. **Match existing test naming style** — sentence-style PascalCase: `GetAThousandSortableUniqueIdStringWithoutAnyDuplicates`. Check `UniqueHelperTest.cs` for examples before writing new tests.
+6. **Use `[Theory]` + `[InlineData]` for error/boundary tests** — `[Fact]` for single-case behavior (generation, round-trip, length). `[Theory]` for multiple error inputs (null, empty, whitespace, invalid format).
+7. **Self-contained tests** — no constructor, no `IDisposable`, no shared state. Each test creates its own data. Matches existing `UniqueHelperTest` class structure.
+
+### Naming Patterns
+
+**Private Field Names:**
+
+| Field | Name | Used By |
+|-------|------|---------|
+| DateTime lock | `_dateTimeLock` | `GenerateDateTimeId()` only |
+| DateTime previous | `_previous` (existing) | `GenerateDateTimeId()` only |
+| ULID options | `_ulidOptions` | `GenerateSortableUniqueStringId()` only |
+
+**ByteAether Type Alias (convention, not enforced by analyzer):**
+
+```csharp
+using BaUlid = ByteAether.Ulid.Ulid;
+using BaGenerationOptions = ByteAether.Ulid.GenerationOptions;
+```
+
+Do not use `using ByteAether.Ulid;` as a namespace import — the type `Ulid` collides with the namespace. Fully qualified `ByteAether.Ulid.Ulid` is acceptable but noisy.
+
+### Structure Patterns
+
+**Source:** All new code in existing `UniqueIdHelper.cs`. No new source files.
+
+**Tests:** All new tests in existing `test/Hexalith.Commons.Tests/UniqueIds/UniqueHelperTest.cs`. Same namespace: `Hexalith.Commons.Tests.UniqueIds`. Do not create new namespaces. Update the class-level `<summary>` to include ULID test coverage.
+
+**Method Ordering:** StyleCop SA1201 enforces alphabetical ordering within visibility groups. Do not attempt to group by feature.
+
+```csharp
+// Alphabetical ordering (enforced by analyzer):
+private static readonly Lock _dateTimeLock = new();
+private static readonly DateTime _previous = DateTime.MinValue;
+private static readonly BaGenerationOptions _ulidOptions = new() { ... };
+
+public static DateTimeOffset ExtractTimestamp(string ulid) { ... }
+public static string GenerateDateTimeId() { ... }
+public static string GenerateSortableUniqueStringId() { ... }
+public static string GenerateUniqueStringId() { ... }
+public static Guid ToGuid(string ulid) { ... }
+public static string ToSortableUniqueId(Guid guid) { ... }
+```
+
+**Field Ownership — No Cross-Strategy State:**
+- `_dateTimeLock` and `_previous` → ONLY `GenerateDateTimeId()`
+- `_ulidOptions` → ONLY `GenerateSortableUniqueStringId()`
+- `GenerateUniqueStringId()` → NO shared state
+
+### Process Patterns
+
+**Validation Pattern for String Input Methods:**
+
+```csharp
+public static DateTimeOffset ExtractTimestamp(string ulid)
+{
+    ArgumentException.ThrowIfNullOrWhiteSpace(ulid);
+    try
+    {
+        return BaUlid.Parse(ulid).Time;
+    }
+    catch (Exception ex) when (ex is not ArgumentException)
+    {
+        throw new FormatException($"The value '{ulid}' is not a valid ULID string", ex);
+    }
+}
+```
+
+Notes:
+- String interpolation in the `FormatException` message is correct — this is the throw path, not the hot path
+- ULID operations are culture-invariant (Crockford Base32 is ASCII-only). Do not add `CultureInfo` parameters.
+
+**Generation Method Exceptions:**
+`GenerateSortableUniqueStringId()` has no input. Any ByteAether exception (system clock issue, library bug) is truly exceptional — let it propagate raw. Do not wrap. Document in `<remarks>` XML tag if applicable.
+
+**Round-Trip Test Pattern:**
+
+```csharp
+[Fact]
+public void ConvertSortableUniqueIdToGuidAndBackShouldReturnOriginalValue()
+{
+    string original = UniqueIdHelper.GenerateSortableUniqueStringId();
+    Guid guid = UniqueIdHelper.ToGuid(original);
+    string roundTripped = UniqueIdHelper.ToSortableUniqueId(guid);
+    roundTripped.ShouldBe(original, "round-trip conversion should preserve the original ULID string");
+}
+```
+
+Note: Guid → Ulid → Guid round-trip direction needs verification during implementation — may or may not preserve the original Guid due to endianness.
+
+**Theory Test Pattern:**
+
+```csharp
+[Theory]
+[InlineData(null)]
+[InlineData("")]
+[InlineData("   ")]
+public void ExtractTimestampFromNullOrWhiteSpaceThrowsArgumentException(string? ulid)
+{
+    Should.Throw<ArgumentException>(() => UniqueIdHelper.ExtractTimestamp(ulid!));
+}
+
+[Theory]
+[InlineData("short")]
+[InlineData("THIS_IS_NOT_A_VALID_ULID!!")]
+[InlineData("01ARZ3NDEKTSV4RRFFQ69G5FA!")]
+public void ExtractTimestampFromInvalidFormatThrowsFormatException(string ulid)
+{
+    Should.Throw<FormatException>(() => UniqueIdHelper.ExtractTimestamp(ulid));
+}
+```
+
+### Anti-Patterns (Top 3 Most Likely Agent Mistakes)
+
+```csharp
+// 1. WRONG: ByteAether type leaking into public API
+public static ByteAether.Ulid.Ulid GenerateUlid()  // NO — return string
+
+// 2. WRONG: Duplicating ByteAether's monotonicity logic
+private static BaUlid _previousUlid;  // NO — ByteAether owns this
+public static string GenerateSortableUniqueStringId()
+{
+    using (_ulidLock.EnterScope())
+    {
+        var ulid = BaUlid.New(_ulidOptions);
+        while (ulid <= _previousUlid) { ... }  // NO!
+    }
+}
+
+// 3. WRONG: Duplicating validation that ByteAether already does
+if (ulid.Length != 26) throw new FormatException(...);  // NO — let ByteAether validate
+if (!IsValidCrockford(ulid)) throw new FormatException(...);  // NO — don't duplicate
+```
+
+## Project Structure & Boundaries
+
+### Complete Project Directory Structure
+
+```
+Hexalith.Commons/
+├── Hexalith.Builds/                          # Submodule (shared across repos)
+│   └── Directory.Packages.props              # ✏️ MODIFY: add ByteAether.Ulid version
+├── src/
+│   └── libraries/
+│       └── Hexalith.Commons.UniqueIds/
+│           ├── Hexalith.Commons.UniqueIds.csproj  # ✏️ MODIFY: add PackageReference
+│           └── UniqueIdHelper.cs                  # ✏️ MODIFY: add 4 methods, rename lock
+├── test/
+│   └── Hexalith.Commons.Tests/
+│       ├── Hexalith.Commons.Tests.csproj          # (unchanged)
+│       └── UniqueIds/
+│           └── UniqueHelperTest.cs                # ✏️ MODIFY: add ~10 test methods
+└── (all other files unchanged)
+```
+
+**Legend:** ✏️ = modified file. No new files created.
+
+### Files Modified — Detailed
+
+| File | Change | FR Coverage |
+|------|--------|-------------|
+| `Hexalith.Builds/Directory.Packages.props` | Add `<PackageVersion Include="ByteAether.Ulid" Version="x.x.x" />` | Prerequisite for all FRs |
+| `src/.../Hexalith.Commons.UniqueIds.csproj` | Add `<PackageReference Include="ByteAether.Ulid" />` (no version — centralized) | Prerequisite for all FRs |
+| `src/.../UniqueIdHelper.cs` | Rename `_lock` → `_dateTimeLock`, add `_ulidOptions` field, add 4 public methods | FR1-FR9 |
+| `test/.../UniqueHelperTest.cs` | Add ~10 test methods covering all new functionality | FR4, FR5, FR6-FR9 verification |
+
+### Architectural Boundaries
+
+**Public API Boundary:**
+```
+Consumer code
+    ↓ calls
+UniqueIdHelper (public static methods — string, Guid, DateTimeOffset)
+    ↓ delegates internally
+ByteAether.Ulid (private, never exposed)
+```
+
+The boundary is the `UniqueIdHelper` class surface. Everything behind it is an implementation detail. Consumers reference `Hexalith.Commons.UniqueIds` only — never `ByteAether.Ulid`.
+
+**Package Dependency Boundary:**
+```
+Hexalith.Commons.UniqueIds.csproj
+    → ByteAether.Ulid (runtime dependency, version in Directory.Packages.props)
+
+Hexalith.Commons.Tests.csproj
+    → Hexalith.Commons.UniqueIds (project reference, existing)
+    → (no direct ByteAether reference needed in tests)
+```
+
+**Thread Safety Boundary:**
+```
+GenerateDateTimeId()              → _dateTimeLock + _previous      (self-contained)
+GenerateSortableUniqueStringId()  → _ulidOptions (ByteAether sync) (self-contained)
+GenerateUniqueStringId()          → stateless                      (no synchronization)
+ExtractTimestamp()                → stateless parse                (no synchronization)
+ToGuid()                          → stateless conversion            (no synchronization)
+ToSortableUniqueId()              → stateless conversion            (no synchronization)
+```
+
+Each ID strategy is an isolated island — no shared mutable state between strategies.
+
+### Requirements to Structure Mapping
+
+| FR | Method | File |
+|----|--------|------|
+| FR1 (Sortable unique ID) | `GenerateSortableUniqueStringId()` | `UniqueIdHelper.cs` |
+| FR2 (Base64URL unique ID) | `GenerateUniqueStringId()` | `UniqueIdHelper.cs` (existing, verify) |
+| FR3 (DateTime ID) | `GenerateDateTimeId()` | `UniqueIdHelper.cs` (existing, unchanged) |
+| FR4 (Concurrent generation) | Tested via async concurrent test | `UniqueHelperTest.cs` |
+| FR5 (Monotonic ordering) | Configured via `_ulidOptions` field | `UniqueIdHelper.cs` |
+| FR6 (Timestamp extraction) | `ExtractTimestamp()` | `UniqueIdHelper.cs` |
+| FR7 (ULID to Guid) | `ToGuid()` | `UniqueIdHelper.cs` |
+| FR8 (Guid to ULID) | `ToSortableUniqueId()` | `UniqueIdHelper.cs` |
+| FR9 (Round-trip) | Tested via round-trip conversion test | `UniqueHelperTest.cs` |
+| FR10-FR12 (Discoverability) | XML docs | `UniqueIdHelper.cs` + README |
+| FR13-FR14 (Coexistence) | Independent state per strategy | `UniqueIdHelper.cs` |
+
+### Data Flow
+
+```
+ULID Generation:
+Ulid.New(_ulidOptions) → ByteAether.Ulid.Ulid struct → .ToString() → 26-char string → consumer
+
+Timestamp Extraction:
+string → BaUlid.Parse(ulid) → ByteAether.Ulid.Ulid struct → .Time → DateTimeOffset → consumer
+
+ULID to Guid:
+string → BaUlid.Parse(ulid) → ByteAether.Ulid.Ulid struct → .ToGuid() → System.Guid → consumer
+
+Guid to ULID:
+System.Guid → new BaUlid(guid.ToByteArray()) → ByteAether.Ulid.Ulid struct → .ToString() → string → consumer
+```
+
+## Architecture Validation Results
+
+### Coherence Validation ✅
+
+**Decision Compatibility:** All 8 ADRs are mutually compatible. One verification item: confirm ByteAether's default monotonicity behavior during implementation.
+
+**Pattern Consistency:** All patterns align with decisions, project-context rules, and existing codebase conventions. No contradictions found.
+
+**Structure Alignment:** 4-file modification footprint aligns with all decisions. No structural conflicts.
+
+### Requirements Coverage ✅
+
+| Category | Coverage |
+|----------|----------|
+| Functional Requirements (FR1-FR14) | 14/14 covered (FR11-FR12 are documentation tasks) |
+| Non-Functional Requirements | All covered — performance, compatibility, ULID spec conformance |
+| User Journeys (Marco, Priya, Sam, Li) | All supported by the API surface and conversion utilities |
+
+### Implementation Readiness ✅
+
+| Dimension | Status |
+|-----------|--------|
+| Decision documentation | 8 ADRs with rationale and priority tiers |
+| Code patterns | Exact code examples for validation, generation, testing |
+| Structure mapping | All FRs mapped to specific files |
+| Enforcement rules | 4 CRITICAL + 3 SHOULD — tiered for agent guidance |
+| Anti-patterns | Top 3 most likely agent mistakes documented |
+
+### Gap Analysis
+
+**Items to Verify During Implementation:**
+1. ByteAether 1.3.2 exact API names (`MonotonicityMode`, `GenerationOptions`, `Parse`, `.Time`, `.ToGuid()`)
+2. ByteAether thread safety model — determines whether `_ulidLock` is needed
+3. Guid → Ulid → Guid round-trip preservation
+
+**Deferred (Post-MVP):**
+- README comparison table and code examples (FR11-FR12)
+- Performance benchmark test
+- `SortableUniqueId` value object (Phase 2)
+
+### Architecture Completeness Checklist
+
+**✅ Requirements Analysis**
+- [x] Project context thoroughly analyzed (56 rules loaded)
+- [x] Scale and complexity assessed (Low)
+- [x] Technical constraints identified (5 analyzers, centralized packages, submodule)
+- [x] Cross-cutting concerns mapped (thread safety, backward compat, dependency management)
+
+**✅ Architectural Decisions**
+- [x] 8 ADRs documented with rationale and priority tiers
+- [x] Technology stack fully specified (ByteAether.Ulid, .NET 10, C# latest)
+- [x] Dependency strategy defined (pin version, wrap behind API)
+- [x] Performance considerations addressed (separate locks, ByteAether benchmarks)
+
+**✅ Implementation Patterns**
+- [x] Naming conventions established (fields, parameters, test methods)
+- [x] Validation patterns defined with code examples
+- [x] Test patterns specified (Fact, Theory, async, round-trip)
+- [x] 4 CRITICAL + 3 SHOULD enforcement rules tiered
+
+**✅ Project Structure**
+- [x] Complete file modification list (4 files, 0 new)
+- [x] Architectural boundaries defined (API, package, thread safety)
+- [x] All 14 FRs mapped to specific files and methods
+- [x] Data flow documented for all operations
+
+### Architecture Readiness Assessment
+
+**Overall Status:** READY FOR IMPLEMENTATION
+
+**Confidence Level:** High — low-complexity enhancement to a well-understood codebase with comprehensive patterns and a 12-step test-gated implementation sequence.
+
+**Key Strengths:**
+- Single class, 4 files — minimal blast radius
+- ByteAether.Ulid handles the hard parts (monotonicity, Crockford Base32, overflow prevention)
+- Tiered enforcement rules prevent the most costly agent mistakes
+- Test-gated implementation sequence catches regressions at each step
+
+**Areas for Future Enhancement (Phase 2+):**
+- `SortableUniqueId` value object with operators, parsing, implicit conversions
+- `TryExtractTimestamp` / Try-pattern overloads
+- Anti-enumeration monotonicity options
+- ULID-based correlation ID middleware
+
+### Implementation Handoff
+
+**AI Agent Guidelines:**
+- Follow all CRITICAL enforcement rules exactly — violations produce broken code
+- Verify ByteAether API names against actual 1.3.2 package before implementing
+- Follow the 12-step implementation sequence — each step is gated by tests
+- Refer to this document for all architectural questions
+
+**First Implementation Priority:**
+Add `ByteAether.Ulid` to `Directory.Packages.props` in `Hexalith.Builds` submodule (requires user approval for submodule modification).

--- a/_bmad-output/planning-artifacts/epics.md
+++ b/_bmad-output/planning-artifacts/epics.md
@@ -1,0 +1,275 @@
+---
+stepsCompleted: ['step-01-validate-prerequisites', 'step-02-design-epics', 'step-03-create-stories', 'step-04-final-validation']
+inputDocuments: ['prd.md', 'architecture.md']
+---
+
+# Hexalith.Commons - Epic Breakdown
+
+## Overview
+
+This document provides the complete epic and story breakdown for Hexalith.Commons, decomposing the requirements from the PRD and Architecture requirements into implementable stories.
+
+## Requirements Inventory
+
+### Functional Requirements
+
+FR1: Developer can generate a sortable unique string identifier that is chronologically ordered and distributed-safe
+FR2: Developer can generate a non-sortable unique string identifier encoded in Base64URL format
+FR3: Developer can generate a datetime-based unique string identifier (existing, unchanged)
+FR4: Developer can generate sortable IDs concurrently from multiple threads without duplicates
+FR5: Developer can generate sortable IDs within the same millisecond that maintain monotonic ordering
+FR6: Developer can extract the creation timestamp from a ULID string as a `DateTimeOffset`
+FR7: Developer can convert a ULID string to a `Guid`
+FR8: Developer can convert a `Guid` to a ULID string
+FR9: Developer can round-trip between ULID and Guid without data loss
+FR10: Developer can discover all ID generation methods via IntelliSense with XML documentation
+FR11: Developer can determine which ID method to use from a README comparison table
+FR12: Developer can see code examples for each method in the README
+FR13: Developer can use all three ID strategies (DateTime, Base64URL, ULID) independently within the same application
+FR14: Developer can adopt ULID for new code without affecting existing code that uses other ID methods
+
+### NonFunctional Requirements
+
+NFR1: `GenerateSortableUniqueStringId()` completes in < 1 microsecond per call (matching ByteAether.Ulid benchmarks)
+NFR2: Zero heap allocations on the generation hot path beyond the returned string
+NFR3: Lock contention under concurrent load must not degrade throughput by more than 10% vs single-threaded
+NFR4: `GenerateUniqueStringId()` Base64URL update must not degrade performance compared to current `Replace`-based implementation
+NFR5: .NET 10+ target framework
+NFR6: No platform-specific dependencies — runs on Windows, Linux, macOS
+NFR7: ByteAether.Ulid version pinned in centralized `Directory.Packages.props`
+NFR8: ULID output conforms to the ULID specification — interoperable with any ULID implementation in any language
+
+### Additional Requirements
+
+- ADR-001: Use ByteAether.Ulid (not Cysharp/Ulid as PRD specified) — overflow safety, .NET 10/C# 14 alignment
+- ADR-002: Separate locks per ID strategy — rename existing `_lock` to `_dateTimeLock`, no cross-strategy contention
+- ADR-003: Characterization test required for Base64URL backward compatibility (assert character set `A-Za-z0-9-_` and length 22 chars across 10,000 IDs)
+- ADR-004: `ToGuid()` preserves identity not sort order — must document caveat in XML docs
+- ADR-005: No ByteAether types in public API — use `string`, `Guid`, `DateTimeOffset` only
+- ADR-006: Exception-based error handling — `ThrowIfNullOrWhiteSpace` + `FormatException` for invalid ULID format
+- ADR-007: Default monotonic ordering — ULID spec compliant
+- ADR-008: Static readonly field for `GenerationOptions` — CLR thread-safe init
+- Add `ByteAether.Ulid` to `Directory.Packages.props` in `Hexalith.Builds` submodule (requires submodule approval)
+- Follow 12-step test-gated implementation sequence from Architecture
+- No new files — all changes in 4 existing files only
+- Use type aliases (`BaUlid`, `BaGenerationOptions`) to avoid namespace collision
+- Match existing test naming style (sentence-style PascalCase)
+
+### UX Design Requirements
+
+N/A — This is a NuGet library with no UI component.
+
+### FR Coverage Map
+
+| FR | Epic | Description |
+|----|------|-------------|
+| FR1 | Epic 2 | Sortable unique ID generation |
+| FR2 | Epic 1 | Base64URL encoding verified/preserved |
+| FR3 | Epic 1 | DateTime ID unchanged |
+| FR4 | Epic 2 | Concurrent generation without duplicates |
+| FR5 | Epic 2 | Monotonic ordering within same millisecond |
+| FR6 | Epic 3 | Timestamp extraction from ULID |
+| FR7 | Epic 3 | ULID to Guid conversion |
+| FR8 | Epic 3 | Guid to ULID conversion |
+| FR9 | Epic 3 | Lossless round-trip |
+| FR10 | Epic 4 | XML documentation on all methods |
+| FR11 | Epic 4 | README comparison table |
+| FR12 | Epic 4 | Code examples in README |
+| FR13 | Epic 1 | All three strategies coexist independently |
+| FR14 | Epic 2 | Incremental ULID adoption |
+
+## Epic List
+
+### Epic 1: Foundation & Backward Compatibility
+Developers can trust that existing ID methods (`GenerateDateTimeId()`, `GenerateUniqueStringId()`) continue to work identically after the ByteAether.Ulid dependency is added, the lock strategy is refactored, and Base64URL output is verified.
+**FRs covered:** FR2, FR3, FR13
+
+### Epic 2: Sortable Unique ID Generation
+Developers can generate chronologically sortable, distributed-safe ULID identifiers — the core capability for event sourcing, aggregate snapshots, and any use case requiring natural ordering.
+**FRs covered:** FR1, FR4, FR5, FR14
+
+### Epic 3: ID Conversion & Interoperability
+Developers can convert between ULID strings and Guids, extract timestamps from ULIDs, and bridge old/new ID systems with lossless round-trip conversion.
+**FRs covered:** FR6, FR7, FR8, FR9
+
+### Epic 4: API Documentation & Discoverability
+Developers can discover all ID strategies via IntelliSense XML docs and a README comparison table with code examples, enabling 30-second decision-making.
+**FRs covered:** FR10, FR11, FR12
+
+## Epic 1: Foundation & Backward Compatibility
+
+Developers can trust that existing ID methods (`GenerateDateTimeId()`, `GenerateUniqueStringId()`) continue to work identically after the ByteAether.Ulid dependency is added, the lock strategy is refactored, and Base64URL output is verified.
+
+### Story 1.1: Add ByteAether.Ulid Package Dependency
+
+As a Hexalith module developer,
+I want the ByteAether.Ulid package added to the project infrastructure,
+So that ULID generation capabilities are available for implementation.
+
+**Acceptance Criteria:**
+
+**Given** the `Hexalith.Builds` submodule contains `Directory.Packages.props`
+**When** a developer checks the package configuration
+**Then** `ByteAether.Ulid` is listed with a pinned version (1.3.2 or later, supporting monotonic generation options)
+**And** `Hexalith.Commons.UniqueIds.csproj` includes a `<PackageReference Include="ByteAether.Ulid" />` (no version — centralized)
+**And** the project builds successfully with no warnings or errors
+**And** all existing tests pass unchanged
+**And** the submodule PR includes a justification that adding a `Directory.Packages.props` entry does not add transitive references to other projects
+
+### Story 1.2: Lock Existing Behavior and Refactor Lock Strategy
+
+As a Hexalith module developer,
+I want regression tests that lock down existing behavior and the lock strategy refactored for isolation,
+So that any future changes are proven safe by test coverage and each ID strategy has independent synchronization.
+
+**Acceptance Criteria:**
+
+**Given** the existing `UniqueHelperTest.cs` test file
+**When** the regression tests run
+**Then** `GenerateDateTimeId()` produces a 17-character datetime string
+**And** `GenerateUniqueStringId()` produces a 22-character string using only `A-Za-z0-9-_` characters (Base64URL character set)
+**And** the characterization test validates character set and length across 10,000 generated IDs (per ADR-003)
+**And** all new test methods follow the existing sentence-style PascalCase naming convention
+
+**Given** the existing `_lock` field in `UniqueIdHelper.cs`
+**When** the field is renamed to `_dateTimeLock`
+**Then** only `GenerateDateTimeId()` uses `_dateTimeLock`
+**And** `GenerateUniqueStringId()` remains stateless (no lock)
+**And** the lock rename is a standalone commit for clean `git bisect` (per Architecture)
+**And** all existing and new regression tests pass after the rename
+
+## Epic 2: Sortable Unique ID Generation
+
+Developers can generate chronologically sortable, distributed-safe ULID identifiers — the core capability for event sourcing, aggregate snapshots, and any use case requiring natural ordering.
+
+### Story 2.1: Implement Sortable Unique ID Generation
+
+As a Hexalith module developer,
+I want a `GenerateSortableUniqueStringId()` method that produces ULID-based identifiers,
+So that my events, aggregates, and projections sort chronologically without custom comparers.
+
+**Acceptance Criteria:**
+
+**Given** the `UniqueIdHelper` static class
+**When** a developer calls `GenerateSortableUniqueStringId()`
+**Then** it returns a 26-character Crockford Base32 string conforming to the ULID specification
+**And** no ByteAether types appear in the public API — only `string` is returned (per ADR-005)
+**And** a `_ulidOptions` static readonly field configures monotonic ordering (per ADR-007, ADR-008)
+**And** the exact ByteAether.Ulid API names for generation options and monotonicity configuration are verified before implementation
+
+**Given** 1,000 sequential calls to `GenerateSortableUniqueStringId()`
+**When** the results are sorted via `string.Compare`
+**Then** lexicographic order matches chronological generation order
+
+**Given** 100 parallel tasks each calling `GenerateSortableUniqueStringId()`
+**When** all tasks complete
+**Then** all 100 IDs are unique (zero duplicates)
+
+**Given** multiple calls within the same millisecond
+**When** IDs are generated rapidly
+**Then** monotonic ordering is maintained (each ID is greater than the previous)
+
+**And** all existing tests continue to pass
+
+**Note:** Performance benchmarking (NFR1 — sub-microsecond per call) is deferred to post-MVP per Architecture decision. Coexistence (FR13/FR14) is structurally guaranteed by isolated per-strategy state (ADR-002) and verified by the regression AC.
+
+## Epic 3: ID Conversion & Interoperability
+
+Developers can convert between ULID strings and Guids, extract timestamps from ULIDs, and bridge old/new ID systems with lossless round-trip conversion.
+
+### Story 3.1: Extract Timestamp from ULID
+
+As a Hexalith module developer,
+I want to extract the creation timestamp from a ULID string,
+So that I can determine when an event or entity was created directly from its ID without querying additional metadata.
+
+**Acceptance Criteria:**
+
+**Given** a valid ULID string generated by `GenerateSortableUniqueStringId()`
+**When** a developer calls `ExtractTimestamp(string ulid)`
+**Then** it returns a `DateTimeOffset` representing the ULID's creation time
+**And** the returned `DateTimeOffset` represents UTC time (ULID timestamps are Unix epoch milliseconds)
+**And** the returned timestamp is within 1 millisecond of the actual generation time
+
+**Given** a null, empty, or whitespace string
+**When** a developer calls `ExtractTimestamp()`
+**Then** an `ArgumentException` is thrown (per ADR-006)
+
+**Given** an invalid ULID format string (e.g., "short", "THIS_IS_NOT_A_VALID_ULID!!")
+**When** a developer calls `ExtractTimestamp()`
+**Then** a `FormatException` is thrown with a descriptive message (per ADR-006)
+
+**And** all existing tests continue to pass
+
+### Story 3.2: Bidirectional ULID-Guid Conversion
+
+As a Hexalith module developer,
+I want to convert between ULID strings and Guids,
+So that I can interoperate with external systems that require Guid identifiers while maintaining ULID-based ordering internally.
+
+**Acceptance Criteria:**
+
+**Given** a valid ULID string
+**When** a developer calls `ToGuid(string ulid)`
+**Then** it returns a `Guid` that preserves the ULID's identity (per ADR-004)
+**And** no ByteAether types appear in the method signature (per ADR-005)
+
+**Given** a `Guid` value
+**When** a developer calls `ToSortableUniqueId(Guid guid)`
+**Then** it returns a 26-character ULID string
+
+**Given** a ULID string converted to Guid via `ToGuid()` then back via `ToSortableUniqueId()`
+**When** the round-trip completes
+**Then** the original ULID string is returned identically (lossless round-trip per FR9)
+
+**Given** a null, empty, or whitespace string passed to `ToGuid()`
+**When** the method is called
+**Then** an `ArgumentException` is thrown (per ADR-006)
+
+**Given** an invalid ULID format string passed to `ToGuid()`
+**When** the method is called
+**Then** a `FormatException` is thrown (per ADR-006)
+
+**Given** a non-ULID Guid (e.g., `Guid.NewGuid()`) passed to `ToSortableUniqueId()`
+**When** the method is called
+**Then** it returns a valid ULID string (does not throw)
+**And** `ExtractTimestamp()` on the result returns a `DateTimeOffset` (does not throw — per Architecture edge case test)
+
+**And** all existing tests continue to pass
+
+## Epic 4: API Documentation & Discoverability
+
+Developers can discover all ID strategies via IntelliSense XML docs and a README comparison table with code examples, enabling 30-second decision-making.
+
+### Story 4.1: Complete XML Documentation on All Public Methods
+
+As a Hexalith module developer,
+I want complete XML documentation on all `UniqueIdHelper` public methods,
+So that I can discover and understand each ID strategy directly via IntelliSense without leaving my editor.
+
+**Acceptance Criteria:**
+
+**Given** all public methods on `UniqueIdHelper`
+**When** a developer hovers over any method in their IDE
+**Then** they see `<summary>`, `<param>`, and `<returns>` XML documentation
+**And** `ToGuid()` includes a `<remarks>` warning that conversion preserves identity but not sort order (per ADR-004)
+**And** `ToSortableUniqueId(Guid)` includes a `<remarks>` warning that non-ULID Guids produce a valid string but with meaningless timestamp (per ADR-004)
+**And** existing methods (`GenerateDateTimeId`, `GenerateUniqueStringId`) are reviewed and updated if their XML documentation is incomplete or inconsistent with new methods
+**And** the project builds with no documentation warnings
+
+### Story 4.2: Create README with Comparison Table and Code Examples
+
+As a NuGet consumer evaluating ID generation libraries,
+I want a README with a comparison table and code examples for all methods,
+So that I can choose the right ID strategy in under 30 seconds.
+
+**Acceptance Criteria:**
+
+**Given** the `Hexalith.Commons.UniqueIds` package README
+**When** a developer reads the documentation
+**Then** it contains a comparison table showing all three ID strategies with columns: Method, Format, Length, Sortable, Distributed-Safe
+**And** it contains code examples for every public method (`GenerateDateTimeId`, `GenerateUniqueStringId`, `GenerateSortableUniqueStringId`, `ExtractTimestamp`, `ToGuid`, `ToSortableUniqueId`)
+**And** it contains NuGet installation instructions
+**And** the comparison table makes the right choice obvious for common use cases (event sourcing → ULID, legacy compatibility → Base64URL, single-machine → DateTime)
+**And** the NuGet package description includes searchable terms (ULID, sortable IDs, Base64URL)
+**And** the README is referenced in `Hexalith.Commons.UniqueIds.csproj` via `<PackageReadmeFile>` for NuGet package display

--- a/_bmad-output/planning-artifacts/prd.md
+++ b/_bmad-output/planning-artifacts/prd.md
@@ -1,0 +1,221 @@
+---
+stepsCompleted: ['step-01-init', 'step-02-discovery', 'step-02b-vision', 'step-02c-executive-summary', 'step-03-success', 'step-04-journeys', 'step-05-domain', 'step-06-innovation', 'step-07-project-type', 'step-08-scoping', 'step-09-functional', 'step-10-nonfunctional', 'step-11-polish']
+inputDocuments: ['project-context.md']
+workflowType: 'prd'
+classification:
+  projectType: 'developer_tool'
+  domain: 'general'
+  complexity: 'low'
+  projectContext: 'brownfield'
+decisions:
+  - 'Use Cysharp/Ulid as external dependency'
+  - 'Verify Base64URL encoding change is backward-compatible'
+  - 'New method: GenerateSortableUniqueStringId() returns 26-char ULID'
+documentCounts:
+  briefs: 0
+  research: 0
+  projectDocs: 1
+---
+
+# Product Requirements Document - Hexalith.Commons.UniqueIds
+
+**Author:** JeromePiquot
+**Date:** 2026-03-14
+
+## Executive Summary
+
+Hexalith.Commons.UniqueIds is the shared identifier generation library for the Hexalith ecosystem — used by both internal modules and external consumers. Today it offers two ID strategies: human-readable DateTime IDs (sortable, single-machine) and Base64-encoded GUID IDs (distributed-safe, unsorted). This enhancement fills a critical gap by adding ULID-based sortable unique identifiers that are both chronologically ordered and distributed-safe — directly addressing event ordering requirements in Hexalith's DDD/CQRS architecture. The existing GUID-based method is also updated to use proper Base64URL encoding, replacing the current manual character substitution hack.
+
+### What Makes This Special
+
+Three ID strategies under one static helper, each purpose-built for a specific use case — no external decision-making required. The ULID addition eliminates the forced trade-off between sortability and distributed uniqueness. Events, aggregate snapshots, and projections get natural chronological ordering at the ID layer, so every downstream system — event stores, read models, logs — benefits without additional sorting logic. Built on the battle-tested `Cysharp/Ulid` library rather than a custom implementation, keeping the solution reliable and the codebase lean.
+
+### Project Classification
+
+- **Project Type:** Developer tool (NuGet library)
+- **Domain:** General — shared infrastructure utility
+- **Complexity:** Low — standard ULID spec via proven library, focused enhancement
+- **Project Context:** Brownfield — extending existing `Hexalith.Commons.UniqueIds` package
+
+## Success Criteria
+
+### User Success
+
+- Developer identifies the right ID method in < 30 seconds from the API surface
+- ULID IDs sort correctly as strings — lexicographic order matches chronological order
+- Conversion utilities (timestamp extraction, Ulid ↔ Guid) are discoverable and intuitive
+- Zero behavior change for `GenerateDateTimeId()` consumers
+
+### Business Success
+
+- Adopted as the default ID strategy for event sourcing across Hexalith modules
+- Single package covers all ID generation needs — no reason to look elsewhere
+
+### Technical Success
+
+- Thread-safe concurrent generation with zero duplicates
+- ULID monotonic ordering within the same millisecond
+- All existing tests pass unchanged
+- New tests cover: uniqueness, sortability, length (26 chars), concurrency, timestamp extraction, Guid conversion
+
+### Measurable Outcomes
+
+- 100% of existing tests pass after Base64URL update
+- Sortability verified: 1000 sequential IDs sort correctly via `string.Compare`
+- Concurrency verified: 100 parallel generations produce 100 unique IDs
+- Round-trip verified: `Ulid → Guid → Ulid` produces identical values
+
+## User Journeys
+
+### Journey 1: Marco, the Hexalith Module Developer (Primary — Success Path)
+
+Marco is building a new `Hexalith.Orders` module. He needs aggregate events to sort chronologically across distributed services. He opens `UniqueIdHelper`, sees three methods with clear XML docs, and picks `GenerateSortableUniqueStringId()`. His events now sort naturally in the event store — no custom comparers, no timestamp columns. When debugging a production issue, he copies a ULID from the logs, extracts the timestamp, and immediately knows when the event was created.
+
+**Reveals:** Clear API naming, XML documentation, timestamp extraction utility.
+
+### Journey 2: Priya, the External NuGet Consumer (Primary — Discovery Path)
+
+Priya finds `Hexalith.Commons.UniqueIds` on NuGet while searching for a lightweight ULID generator for her ASP.NET API. She reads the README, sees the comparison table of three ID strategies, and understands which to use in 30 seconds. She installs the package, calls one static method, and has sortable IDs in her API responses. No configuration, no DI registration, no ceremony.
+
+**Reveals:** README quality, comparison table, zero-config static API, NuGet discoverability.
+
+### Journey 3: Sam, the Migrating Developer (Edge Case — Migration Path)
+
+Sam's team has been using `GenerateUniqueStringId()` for aggregate IDs across three Hexalith modules. Event replay is painful — events are randomly ordered and they're constantly sorting by a separate timestamp field. Sam wants to switch new aggregates to ULID while existing data stays untouched. He uses `GenerateSortableUniqueStringId()` for new aggregates and keeps the old method for existing ones. For interop, he uses the Guid conversion utility when bridging old and new systems. No big-bang migration needed.
+
+**Reveals:** Coexistence of ID strategies, Guid conversion utility, incremental adoption path.
+
+### Journey 4: Li, the Integration Developer (Edge Case — Interop Path)
+
+Li integrates Hexalith with a third-party ERP that only accepts GUIDs. She generates a ULID for internal event ordering, then converts it to a Guid for the ERP API call. When the ERP sends a response with the Guid, she converts back to ULID to correlate with internal events. The round-trip is lossless. She also extracts the timestamp from a ULID during debugging to pinpoint when a failed integration event was created.
+
+**Reveals:** Ulid → Guid → Ulid round-trip, timestamp extraction for debugging, lossless conversion.
+
+### Journey Requirements Summary
+
+| Capability | Journeys | Priority |
+|-----------|----------|----------|
+| `GenerateSortableUniqueStringId()` | Marco, Priya, Sam | MVP Core |
+| Proper Base64URL on existing method | Sam | MVP Core |
+| Timestamp extraction from ULID | Marco, Li | MVP |
+| Ulid ↔ Guid conversion | Sam, Li | MVP |
+| Clear XML documentation | Marco, Priya | MVP |
+| README with comparison table | Priya | MVP |
+| Coexistence of all three ID strategies | Sam | MVP |
+
+## Project Scoping & Phased Development
+
+### MVP Strategy & Philosophy
+
+**MVP Approach:** Problem-solving — deliver the minimum that solves the event ordering gap via ULID, plus conversion utilities.
+**Resource Requirements:** Single developer, 1-2 days of implementation + testing.
+
+### MVP Feature Set (Phase 1)
+
+**Core User Journeys Supported:** Marco (event ordering), Sam (migration/interop), Li (Guid conversion), Priya (discovery)
+
+**Must-Have Capabilities:**
+1. `GenerateSortableUniqueStringId()` — ULID generation via `Cysharp/Ulid`
+2. `GenerateUniqueStringId()` — updated to proper Base64URL encoding
+3. `ExtractTimestamp(string ulid)` — timestamp extraction from ULID
+4. `ToGuid(string ulid)` — ULID to Guid conversion
+5. `ToSortableUniqueId(Guid guid)` — Guid to ULID conversion
+6. Tests: uniqueness, sortability, concurrency, round-trip, timestamp extraction
+7. README: comparison table + code examples for all methods
+
+### Post-MVP Features
+
+**Phase 2 (Growth):**
+- `SortableUniqueId` value object with parsing, comparison operators, implicit conversions
+- Integration with Hexalith DDD abstractions (aggregate root ID base type)
+
+**Phase 3 (Expansion):**
+- ULID-based correlation ID middleware for distributed tracing
+- ID generation telemetry and diagnostics
+
+### Risk Mitigation Strategy
+
+**Technical Risks:** Low — `Cysharp/Ulid` is battle-tested. Only risk is Base64URL output compatibility with current method. Mitigation: unit test that verifies character set is identical (`A-Za-z0-9-_`).
+**Market Risks:** None — internal infrastructure library with known consumers.
+**Resource Risks:** Minimal — single-developer scope. If constrained, drop README update and ship docs later.
+
+## Developer Tool Specific Requirements
+
+### Project-Type Overview
+
+NuGet library targeting .NET 10+ / C# 14+. Single static helper class (`UniqueIdHelper`) with zero-config API. Consumed via `Hexalith.Commons.UniqueIds` package. External dependency on `Cysharp/Ulid` managed through centralized `Directory.Packages.props`.
+
+### API Surface
+
+| Method | Behavior | Returns |
+|--------|----------|---------|
+| `GenerateDateTimeId()` | Unchanged | 17-char datetime string |
+| `GenerateUniqueStringId()` | Updated to proper Base64URL encoding | 22-char Base64URL string |
+| `GenerateSortableUniqueStringId()` | New — generates ULID | 26-char Crockford Base32 string |
+| `ExtractTimestamp(string ulid)` | New — extracts creation time from ULID | `DateTimeOffset` |
+| `ToGuid(string ulid)` | New — converts ULID string to Guid | `Guid` |
+| `ToSortableUniqueId(Guid guid)` | New — converts Guid to ULID string | 26-char string |
+
+### Technical Architecture Considerations
+
+- All methods remain static on `UniqueIdHelper` — no DI, no interfaces, no ceremony
+- Thread safety via `Lock` for methods requiring monotonic guarantees
+- `Cysharp/Ulid` handles ULID internals (timestamp encoding, Crockford Base32, monotonic ordering)
+- Conversion utilities are thin wrappers over `Ulid` struct methods
+
+### Documentation Requirements
+
+- XML documentation on all public methods with `<summary>`, `<param>`, `<returns>`
+- README with code examples for every method
+- Comparison table of all three ID strategies (format, length, sortable, distributed-safe)
+- Installation instructions via NuGet
+
+### Implementation Considerations
+
+- Package version for `Cysharp/Ulid` added to `Directory.Packages.props` in `Hexalith.Builds` submodule — requires approval
+- No migration guide needed — developers simply adopt new methods
+- Existing `GenerateUniqueStringId()` output should remain functionally identical after Base64URL update
+
+## Functional Requirements
+
+### ID Generation
+
+- **FR1:** Developer can generate a sortable unique string identifier that is chronologically ordered and distributed-safe
+- **FR2:** Developer can generate a non-sortable unique string identifier encoded in Base64URL format
+- **FR3:** Developer can generate a datetime-based unique string identifier (existing, unchanged)
+- **FR4:** Developer can generate sortable IDs concurrently from multiple threads without duplicates
+- **FR5:** Developer can generate sortable IDs within the same millisecond that maintain monotonic ordering
+
+### ID Conversion
+
+- **FR6:** Developer can extract the creation timestamp from a ULID string as a `DateTimeOffset`
+- **FR7:** Developer can convert a ULID string to a `Guid`
+- **FR8:** Developer can convert a `Guid` to a ULID string
+- **FR9:** Developer can round-trip between ULID and Guid without data loss
+
+### API Discoverability
+
+- **FR10:** Developer can discover all ID generation methods via IntelliSense with XML documentation
+- **FR11:** Developer can determine which ID method to use from a README comparison table
+- **FR12:** Developer can see code examples for each method in the README
+
+### Coexistence
+
+- **FR13:** Developer can use all three ID strategies (DateTime, Base64URL, ULID) independently within the same application
+- **FR14:** Developer can adopt ULID for new code without affecting existing code that uses other ID methods
+
+## Non-Functional Requirements
+
+### Performance
+
+- ID generation must not become a bottleneck: `GenerateSortableUniqueStringId()` completes in < 1 microsecond per call (matching `Cysharp/Ulid` benchmarks)
+- Zero heap allocations on the generation hot path beyond the returned string
+- Lock contention under concurrent load must not degrade throughput by more than 10% vs single-threaded
+- `GenerateUniqueStringId()` Base64URL update must not degrade performance compared to current `Replace`-based implementation
+
+### Compatibility
+
+- .NET 10+ target framework
+- No platform-specific dependencies — runs on Windows, Linux, macOS
+- `Cysharp/Ulid` version pinned in centralized `Directory.Packages.props`
+- ULID output conforms to the [ULID specification](https://github.com/ulid/spec) — interoperable with any ULID implementation in any language

--- a/src/libraries/Hexalith.Commons.UniqueIds/Hexalith.Commons.UniqueIds.csproj
+++ b/src/libraries/Hexalith.Commons.UniqueIds/Hexalith.Commons.UniqueIds.csproj
@@ -3,4 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ByteAether.Ulid" />
+  </ItemGroup>
 </Project>

--- a/src/libraries/Hexalith.Commons.UniqueIds/UniqueIdHelper.cs
+++ b/src/libraries/Hexalith.Commons.UniqueIds/UniqueIdHelper.cs
@@ -9,12 +9,23 @@ using System;
 using System.Globalization;
 using System.Threading;
 
+using BaUlid = ByteAether.Ulid.Ulid;
+
 /// <summary>
 /// Provides helper methods for generating unique IDs.
 /// </summary>
 public static class UniqueIdHelper
 {
     private static readonly Lock _dateTimeLock = new();
+
+    /// <summary>
+    /// Generation options for ULID with monotonic increment to ensure within-millisecond ordering.
+    /// </summary>
+    private static readonly BaUlid.GenerationOptions _ulidOptions = new()
+    {
+        Monotonicity = BaUlid.GenerationOptions.MonotonicityOptions.MonotonicIncrement,
+    };
+
     private static DateTime _previous = DateTime.MinValue;
 
     /// <summary>
@@ -46,6 +57,15 @@ public static class UniqueIdHelper
             return currentDateTime.ToString("yyyyMMddHHmmssfff", CultureInfo.InvariantCulture);
         }
     }
+
+    /// <summary>
+    /// Generates a sortable unique 26-character ID string based on the ULID specification.
+    /// ULIDs are chronologically sortable and distributed-safe, making them ideal for
+    /// event sourcing, aggregate identifiers, and any use case requiring natural ordering.
+    /// </summary>
+    /// <returns>A 26-character Crockford Base32 encoded ULID string.</returns>
+    public static string GenerateSortableUniqueStringId()
+        => BaUlid.New(_ulidOptions).ToString();
 
     /// <summary>
     /// Generates a unique 22-character ID string derived from a GUID encoded in Base64 URL-safe format.

--- a/test/Hexalith.Commons.Tests/UniqueIds/UniqueHelperTest.cs
+++ b/test/Hexalith.Commons.Tests/UniqueIds/UniqueHelperTest.cs
@@ -146,6 +146,97 @@ public partial class UniqueHelperTest
         id.Length.ShouldBe(22, "the id is a base64 string of 16 bytes");
     }
 
+    /// <summary>
+    /// Tests that all three ID strategies (DateTime, Base64URL, ULID) coexist independently
+    /// without interfering with each other, verifying FR14 incremental adoption guarantee.
+    /// </summary>
+    [Fact]
+    public void AllThreeIdStrategiesCoexistIndependently()
+    {
+        string dateTimeId = UniqueIdHelper.GenerateDateTimeId();
+        string uniqueId = UniqueIdHelper.GenerateUniqueStringId();
+        string sortableId = UniqueIdHelper.GenerateSortableUniqueStringId();
+
+        dateTimeId.Length.ShouldBe(17);
+        uniqueId.Length.ShouldBe(22);
+        sortableId.Length.ShouldBe(26);
+    }
+
+    /// <summary>
+    /// Tests that a generated sortable unique string ID is exactly 26 characters
+    /// and contains only valid Crockford Base32 characters conforming to the ULID specification.
+    /// </summary>
+    [Fact]
+    public void GenerateSortableUniqueStringIdProduces26CharCrockfordBase32String()
+    {
+        HashSet<string> ids = [];
+        Regex pattern = CrockfordBase32Pattern();
+        for (int i = 0; i < 1_000; i++)
+        {
+            string id = UniqueIdHelper.GenerateSortableUniqueStringId();
+            id.Length.ShouldBe(26);
+            pattern.IsMatch(id).ShouldBeTrue($"ID '{id}' contains invalid Crockford Base32 characters");
+            _ = ids.Add(id);
+        }
+
+        ids.Count.ShouldBe(1_000);
+    }
+
+    /// <summary>
+    /// Tests that 100 sequential sortable unique IDs are monotonically increasing,
+    /// verifying the monotonic increment behavior within the same millisecond window.
+    /// </summary>
+    [Fact]
+    public void GenerateSortableUniqueStringIdProducesMonotonicallyIncreasingIds()
+    {
+        string previous = UniqueIdHelper.GenerateSortableUniqueStringId();
+        for (int i = 0; i < 99; i++)
+        {
+            string current = UniqueIdHelper.GenerateSortableUniqueStringId();
+            StringComparer.Ordinal.Compare(current, previous).ShouldBeGreaterThan(0);
+            previous = current;
+        }
+    }
+
+    /// <summary>
+    /// Tests that concurrent generation of 100 sortable unique IDs
+    /// produces unique values without any duplicates, verifying
+    /// thread-safety of the ULID generation process.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    [Fact]
+    public async Task GetAHundredConcurrentSortableUniqueIdStringWithoutAnyDuplicatesAsync()
+    {
+        List<Task<string>> tasks = [];
+        for (int i = 0; i < 100; i++)
+        {
+            tasks.Add(Task.Run(UniqueIdHelper.GenerateSortableUniqueStringId));
+        }
+
+        string[] result = await Task.WhenAll(tasks);
+        result.Distinct(StringComparer.Ordinal).Count().ShouldBe(100);
+    }
+
+    /// <summary>
+    /// Tests that 1,000 sequentially generated sortable unique IDs maintain chronological
+    /// order when sorted lexicographically, verifying the ULID specification's sortability guarantee.
+    /// </summary>
+    [Fact]
+    public void GetAThousandSortableUniqueIdStringInChronologicalOrder()
+    {
+        List<string> ids = [];
+        for (int i = 0; i < 1_000; i++)
+        {
+            ids.Add(UniqueIdHelper.GenerateSortableUniqueStringId());
+        }
+
+        List<string> sorted = [.. ids.OrderBy(id => id, StringComparer.Ordinal)];
+        ids.ShouldBe(sorted);
+    }
+
     [GeneratedRegex("^[A-Za-z0-9_-]{22}$")]
     private static partial Regex Base64UrlPattern();
+
+    [GeneratedRegex("^[0-9A-HJKMNP-TV-Z]{26}$")]
+    private static partial Regex CrockfordBase32Pattern();
 }


### PR DESCRIPTION
## Summary
- Add `GenerateSortableUniqueStringId()` method using ByteAether.Ulid with monotonic increment for within-millisecond ordering
- Add ByteAether.Ulid package dependency to Hexalith.Commons.UniqueIds
- Add comprehensive tests: format validation (26-char Crockford Base32), monotonic ordering, concurrency uniqueness, and coexistence with existing ID strategies

## Test plan
- [x] Unit tests verify 26-character Crockford Base32 format across 1,000 IDs
- [x] Monotonic ordering test confirms sequential IDs are strictly increasing
- [x] Concurrency test verifies 100 parallel generations produce no duplicates
- [x] Chronological ordering test validates 1,000 IDs sort lexicographically
- [x] Coexistence test confirms all three ID strategies work independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)