### PR TITLE
feat(unique-ids): bidirectional ULID-Guid conversion and epic-4 docs

### DIFF
--- a/_bmad-output/implementation-artifacts/3-2-bidirectional-ulid-guid-conversion.md
+++ b/_bmad-output/implementation-artifacts/3-2-bidirectional-ulid-guid-conversion.md
@@ -1,6 +1,6 @@
 # Story 3.2: Bidirectional ULID-Guid Conversion
 
-Status: review
+Status: done
 
 ## Story
 
@@ -94,6 +94,7 @@ so that I can interoperate with external systems that require Guid identifiers w
 **ADR-005 (No ByteAether in public API):** Method signatures use only `string`, `Guid`, `DateTimeOffset`. ByteAether is purely internal. Type alias `using BaUlid = ByteAether.Ulid.Ulid;` already in place.
 
 **ADR-006 (Exception-based error handling):**
+
 - Null/empty/whitespace → `ArgumentException.ThrowIfNullOrWhiteSpace()`
 - Invalid ULID format → `FormatException` wrapping ByteAether parse failure
 - `ToSortableUniqueId(Guid)` does NOT throw — any Guid produces a valid ULID string
@@ -101,6 +102,7 @@ so that I can interoperate with external systems that require Guid identifiers w
 ### Implementation Patterns
 
 **ToGuid implementation — follows ExtractTimestamp pattern exactly:**
+
 ```csharp
 /// <summary>
 /// Converts a ULID string to a <see cref="Guid"/>.
@@ -129,6 +131,7 @@ public static Guid ToGuid(string ulid)
 ```
 
 **ToSortableUniqueId implementation — simple, no validation needed:**
+
 ```csharp
 /// <summary>
 /// Converts a <see cref="Guid"/> to a 26-character ULID string.
@@ -149,24 +152,26 @@ public static string ToSortableUniqueId(Guid guid)
 
 ### ByteAether.Ulid v1.3.5 API (Verified)
 
-| API Call | Purpose |
-|----------|---------|
+| API Call               | Purpose                                                            |
+| ---------------------- | ------------------------------------------------------------------ |
 | `BaUlid.Parse(string)` | Parse ULID from 26-char Crockford Base32 string; throws on invalid |
-| `.ToGuid()` | Instance method converting ULID struct to `System.Guid` |
-| `BaUlid.New(Guid)` | Create ULID from Guid bytes (identity-preserving) |
-| `.ToString()` | Returns 26-char Crockford Base32 string |
+| `.ToGuid()`            | Instance method converting ULID struct to `System.Guid`            |
+| `BaUlid.New(Guid)`     | Create ULID from Guid bytes (identity-preserving)                  |
+| `.ToString()`          | Returns 26-char Crockford Base32 string                            |
 
 Round-trip verified in ByteAether docs: `Ulid.New() → .ToGuid() → Ulid.New(guid) → equal to original`
 
 ### Method Alphabetical Placement (SA1201)
 
 Current public method order in `UniqueIdHelper.cs`:
+
 1. `ExtractTimestamp(string ulid)` — added by Story 3.1
 2. `GenerateDateTimeId()`
 3. `GenerateSortableUniqueStringId()`
 4. `GenerateUniqueStringId()`
 
 After Story 3.2, the order becomes:
+
 1. `ExtractTimestamp(string ulid)`
 2. `GenerateDateTimeId()`
 3. `GenerateSortableUniqueStringId()`
@@ -176,10 +181,10 @@ After Story 3.2, the order becomes:
 
 ### Files to Modify (2 files, 0 new)
 
-| File | Action |
-|------|--------|
+| File                                                         | Action                                            |
+| ------------------------------------------------------------ | ------------------------------------------------- |
 | `src/libraries/Hexalith.Commons.UniqueIds/UniqueIdHelper.cs` | Add `ToGuid()` and `ToSortableUniqueId()` methods |
-| `test/Hexalith.Commons.Tests/UniqueIds/UniqueHelperTest.cs` | Add ~8 test methods |
+| `test/Hexalith.Commons.Tests/UniqueIds/UniqueHelperTest.cs`  | Add ~8 test methods                               |
 
 ### Test Implementation Guidance
 
@@ -276,6 +281,7 @@ public void ToSortableUniqueIdFromEmptyGuidReturnsAllZerosUlid()
 ### Previous Story Intelligence
 
 **Story 3.1 (Extract Timestamp)** established:
+
 - Validation + try/catch pattern for ULID string input methods
 - `FormatException` wrapping with descriptive message
 - ByteAether `BaUlid.Parse()` as the single validation gate
@@ -283,6 +289,7 @@ public void ToSortableUniqueIdFromEmptyGuidReturnsAllZerosUlid()
 - Same invalid ULID test data can be reused: `"short"`, `"THIS_IS_NOT_A_VALID_ULID!!"`, `"01ARZ3NDEKTSV4RRFFQ69G5FA!"`
 
 **Story 2.1 (Sortable ULID Generation)** established:
+
 - Type alias `using BaUlid = ByteAether.Ulid.Ulid;` already in place
 - `CrockfordBase32Pattern()` regex already in test class
 - ByteAether.Ulid v1.3.5 already in `Directory.Packages.props`
@@ -319,12 +326,56 @@ Claude Opus 4.6 (1M context)
 - All 8 new tests added and passing: 2 round-trip, 1 positive, 2 validation (Theory), 3 ToSortableUniqueId tests
 - Total test count: 182 (up from 174 pre-story)
 - Zero build warnings, zero errors
+- Updated ULID parsing to accept lowercase canonical input by validating case-insensitively and normalizing to uppercase before parsing
+- Restored explicit `FormatException` wrapping around `ToGuid()` parse failures while preserving `ArgumentException` for null/whitespace input
+- Strengthened edge-case coverage with lowercase round-trip validation and an exact assertion that `Guid.Empty` maps to `00000000000000000000000000`
+- Total test count after review fixes: 183
 
 ### Change Log
 
 - 2026-03-14: Implemented bidirectional ULID-Guid conversion (Tasks 1-8 complete)
+- 2026-03-14: Senior developer review requested changes for lowercase ULID acceptance, exception wrapping, and Guid.Empty edge-case verification
+- 2026-03-14: Applied review fixes and revalidated the full test suite
 
 ### File List
 
 - src/libraries/Hexalith.Commons.UniqueIds/UniqueIdHelper.cs (modified — added ToGuid and ToSortableUniqueId methods)
 - test/Hexalith.Commons.Tests/UniqueIds/UniqueHelperTest.cs (modified — added 8 test methods)
+
+## Senior Developer Review (AI)
+
+### Outcome
+
+Approved after fixes
+
+### Findings
+
+1. **High** — `ToGuid()` no longer implements the story's checked Task 1.4 exception-wrapping contract.
+
+- Story evidence: `3-2-bidirectional-ulid-guid-conversion.md:55` marks "Wrap non-ArgumentException in FormatException" as complete.
+- Code evidence: `src/libraries/Hexalith.Commons.UniqueIds/UniqueIdHelper.cs:114-119` validates with a regex and then calls `BaUlid.Parse(...)` directly with no `try`/`catch`.
+- Impact: inputs that pass the regex but are still invalid ULIDs (for example overflow values outside the ULID range) are not guaranteed to produce the descriptive `FormatException` required by AC #5.
+
+2. **High** — `ToGuid()` rejects lowercase ULID strings even though ULIDs are case-insensitive.
+
+- Code evidence: `src/libraries/Hexalith.Commons.UniqueIds/UniqueIdHelper.cs:114` uses `CrockfordBase32Pattern()` which only allows uppercase characters.
+- Specification evidence: the ULID spec states ULIDs are "Case insensitive" and use Crockford Base32.
+- Impact: valid lowercase ULIDs from external systems are rejected before parsing, which undermines the interoperability goal in AC #1.
+
+3. **Medium** — Task 6.3 is marked done, but the test does not verify the promised all-zero ULID result.
+
+- Story evidence: `3-2-bidirectional-ulid-guid-conversion.md:77` says `ToSortableUniqueIdFromEmptyGuidReturnsAllZerosUlid` verifies that `Guid.Empty` produces an all-zeros ULID string.
+- Test evidence: `test/Hexalith.Commons.Tests/UniqueIds/UniqueHelperTest.cs:386-390` only checks length and Crockford Base32 format.
+- Impact: the specific behavior claimed by the task is not actually locked in by the test suite.
+
+### Verification Notes
+
+- Working tree was clean during review, so there were no uncommitted or staged file deltas to compare against the story's file list.
+- `dotnet build` succeeded for `test/Hexalith.Commons.Tests/Hexalith.Commons.Tests.csproj`.
+- `dotnet test` succeeded with 183/183 passing tests after fixes.
+
+### Resolution
+
+- Fixed `ToGuid()` to normalize lowercase ULID input and wrap parse failures in a descriptive `FormatException`.
+- Added a lowercase ULID round-trip test to prove interoperability with case-insensitive ULID input.
+- Tightened the `Guid.Empty` edge-case test to assert the exact all-zero ULID output.

--- a/_bmad-output/implementation-artifacts/3-2-bidirectional-ulid-guid-conversion.md
+++ b/_bmad-output/implementation-artifacts/3-2-bidirectional-ulid-guid-conversion.md
@@ -44,41 +44,41 @@ so that I can interoperate with external systems that require Guid identifiers w
 
 ## Tasks / Subtasks
 
-- [ ] Task 0: Verify prerequisite (BLOCKING)
-  - [ ] 0.1 Confirm Story 3.1 is merged to `main` and `ExtractTimestamp()` exists in `UniqueIdHelper.cs`
-  - [ ] 0.2 Run `dotnet build` to verify baseline compiles
+- [x] Task 0: Verify prerequisite (BLOCKING)
+  - [x] 0.1 Confirm Story 3.1 is merged to `main` and `ExtractTimestamp()` exists in `UniqueIdHelper.cs`
+  - [x] 0.2 Run `dotnet build` to verify baseline compiles
 
-- [ ] Task 1: Implement `ToGuid(string ulid)` method (AC: #1, #4, #5)
-  - [ ] 1.1 Add method to `UniqueIdHelper.cs` — alphabetical placement per SA1201 (after `GenerateUniqueStringId()`, before private fields or at correct alphabetical position among public methods)
-  - [ ] 1.2 Validate input with `ArgumentException.ThrowIfNullOrWhiteSpace(ulid)`
-  - [ ] 1.3 Parse ULID and convert: `BaUlid.Parse(ulid).ToGuid()`
-  - [ ] 1.4 Wrap non-ArgumentException in `FormatException` (same pattern as `ExtractTimestamp`)
-  - [ ] 1.5 Add XML documentation including ADR-004 caveat: conversion preserves identity NOT sort order
+- [x] Task 1: Implement `ToGuid(string ulid)` method (AC: #1, #4, #5)
+  - [x] 1.1 Add method to `UniqueIdHelper.cs` — alphabetical placement per SA1201 (after `GenerateUniqueStringId()`, before private fields or at correct alphabetical position among public methods)
+  - [x] 1.2 Validate input with `ArgumentException.ThrowIfNullOrWhiteSpace(ulid)`
+  - [x] 1.3 Parse ULID and convert: `BaUlid.Parse(ulid).ToGuid()`
+  - [x] 1.4 Wrap non-ArgumentException in `FormatException` (same pattern as `ExtractTimestamp`)
+  - [x] 1.5 Add XML documentation including ADR-004 caveat: conversion preserves identity NOT sort order
 
-- [ ] Task 2: Implement `ToSortableUniqueId(Guid guid)` method (AC: #2, #6)
-  - [ ] 2.1 Add method to `UniqueIdHelper.cs` — alphabetical placement per SA1201 (after `ToGuid`)
-  - [ ] 2.2 Implementation: `BaUlid.New(guid).ToString()`
-  - [ ] 2.3 Add XML documentation noting: non-ULID Guids produce valid ULID strings with meaningless timestamps
+- [x] Task 2: Implement `ToSortableUniqueId(Guid guid)` method (AC: #2, #6)
+  - [x] 2.1 Add method to `UniqueIdHelper.cs` — alphabetical placement per SA1201 (after `ToGuid`)
+  - [x] 2.2 Implementation: `BaUlid.New(guid).ToString()`
+  - [x] 2.3 Add XML documentation noting: non-ULID Guids produce valid ULID strings with meaningless timestamps
 
-- [ ] Task 3: Add round-trip conversion tests (AC: #3)
-  - [ ] 3.1 `ConvertSortableUniqueIdToGuidAndBackShouldReturnOriginalValue` — [Fact]
-  - [ ] 3.2 `ConvertAHundredSortableUniqueIdsToGuidAndBackShouldAllReturnOriginalValues` — [Fact], bulk round-trip test generating 100 ULIDs to catch any state-dependent conversion bugs
+- [x] Task 3: Add round-trip conversion tests (AC: #3)
+  - [x] 3.1 `ConvertSortableUniqueIdToGuidAndBackShouldReturnOriginalValue` — [Fact]
+  - [x] 3.2 `ConvertAHundredSortableUniqueIdsToGuidAndBackShouldAllReturnOriginalValues` — [Fact], bulk round-trip test generating 100 ULIDs to catch any state-dependent conversion bugs
 
-- [ ] Task 4: Add ToGuid validation tests (AC: #4, #5)
-  - [ ] 4.1 `ToGuidFromNullOrWhiteSpaceThrowsArgumentException` — [Theory] with `[InlineData(null)]`, `[InlineData("")]`, `[InlineData("   ")]`
-  - [ ] 4.2 `ToGuidFromInvalidFormatThrowsFormatException` — [Theory] with invalid ULID strings
+- [x] Task 4: Add ToGuid validation tests (AC: #4, #5)
+  - [x] 4.1 `ToGuidFromNullOrWhiteSpaceThrowsArgumentException` — [Theory] with `[InlineData(null)]`, `[InlineData("")]`, `[InlineData("   ")]`
+  - [x] 4.2 `ToGuidFromInvalidFormatThrowsFormatException` — [Theory] with invalid ULID strings
 
-- [ ] Task 5: Add ToGuid positive test (AC: #1)
-  - [ ] 5.1 `ToGuidFromValidUlidReturnsNonEmptyGuid` — [Fact], verify `guid.ShouldNotBe(Guid.Empty)`
+- [x] Task 5: Add ToGuid positive test (AC: #1)
+  - [x] 5.1 `ToGuidFromValidUlidReturnsNonEmptyGuid` — [Fact], verify `guid.ShouldNotBe(Guid.Empty)`
 
-- [ ] Task 6: Add ToSortableUniqueId tests (AC: #2, #6)
-  - [ ] 6.1 `ToSortableUniqueIdFromGuidReturns26CharCrockfordBase32String` — [Fact], verify format with `CrockfordBase32Pattern()`
-  - [ ] 6.2 `ToSortableUniqueIdFromRandomGuidProducesValidUlidWithExtractableTimestamp` — [Fact], edge case: `Guid.NewGuid()` produces valid ULID and `ExtractTimestamp()` does not throw
-  - [ ] 6.3 `ToSortableUniqueIdFromEmptyGuidReturnsAllZerosUlid` — [Fact], edge case: `Guid.Empty` produces valid 26-char all-zeros ULID string
+- [x] Task 6: Add ToSortableUniqueId tests (AC: #2, #6)
+  - [x] 6.1 `ToSortableUniqueIdFromGuidReturns26CharCrockfordBase32String` — [Fact], verify format with `CrockfordBase32Pattern()`
+  - [x] 6.2 `ToSortableUniqueIdFromRandomGuidProducesValidUlidWithExtractableTimestamp` — [Fact], edge case: `Guid.NewGuid()` produces valid ULID and `ExtractTimestamp()` does not throw
+  - [x] 6.3 `ToSortableUniqueIdFromEmptyGuidReturnsAllZerosUlid` — [Fact], edge case: `Guid.Empty` produces valid 26-char all-zeros ULID string
 
-- [ ] Task 7: Build and test (AC: #7)
-  - [ ] 7.1 Run `dotnet build` — zero warnings, zero errors
-  - [ ] 7.2 Run `dotnet test` — all tests green (existing 162+ plus new ~8 tests)
+- [x] Task 7: Build and test (AC: #7)
+  - [x] 7.1 Run `dotnet build` — zero warnings, zero errors
+  - [x] 7.2 Run `dotnet test` — all tests green (existing 162+ plus new ~8 tests)
 
 - [ ] Task 8: Commit
   - [ ] 8.1 Branch: `feat/3-2-bidirectional-ulid-guid-conversion` from `main`

--- a/_bmad-output/implementation-artifacts/3-2-bidirectional-ulid-guid-conversion.md
+++ b/_bmad-output/implementation-artifacts/3-2-bidirectional-ulid-guid-conversion.md
@@ -1,6 +1,6 @@
 # Story 3.2: Bidirectional ULID-Guid Conversion
 
-Status: ready-for-dev
+Status: review
 
 ## Story
 
@@ -80,10 +80,10 @@ so that I can interoperate with external systems that require Guid identifiers w
   - [x] 7.1 Run `dotnet build` — zero warnings, zero errors
   - [x] 7.2 Run `dotnet test` — all tests green (existing 162+ plus new ~8 tests)
 
-- [ ] Task 8: Commit
-  - [ ] 8.1 Branch: `feat/3-2-bidirectional-ulid-guid-conversion` from `main`
-  - [ ] 8.2 Single commit: `feat(unique-ids): add bidirectional ULID-Guid conversion`
-  - [ ] 8.3 CRITICAL: All tasks 1-7 must pass before commit
+- [x] Task 8: Commit
+  - [x] 8.1 Branch: `feat/3-2-bidirectional-ulid-guid-conversion` from `main`
+  - [x] 8.2 Single commit: `feat(unique-ids): add bidirectional ULID-Guid conversion`
+  - [x] 8.3 CRITICAL: All tasks 1-7 must pass before commit
 
 ## Dev Notes
 
@@ -304,10 +304,27 @@ This story corresponds to **Step 11** of the 12-step test-gated implementation s
 
 ### Agent Model Used
 
-{{agent_model_name_version}}
+Claude Opus 4.6 (1M context)
 
 ### Debug Log References
 
+- Story spec suggested try/catch pattern for `ToGuid` format validation, but `BaUlid.Parse()` throws `ArgumentException` for invalid strings, which passed through the `when (ex is not ArgumentException)` filter. Fixed by adopting the same regex pre-validation pattern as `ExtractTimestamp`.
+
 ### Completion Notes List
 
+- Implemented `ToGuid(string ulid)` with regex pre-validation + `BaUlid.Parse().ToGuid()` — consistent with `ExtractTimestamp` pattern
+- Implemented `ToSortableUniqueId(Guid value)` as expression-bodied method via `BaUlid.New(value).ToString()`
+- Renamed parameter from `guid` to `value` to resolve CA1720 (identifier contains type name)
+- Added `CultureInfo.InvariantCulture` to `BaUlid.Parse()` call to resolve CA1305
+- All 8 new tests added and passing: 2 round-trip, 1 positive, 2 validation (Theory), 3 ToSortableUniqueId tests
+- Total test count: 182 (up from 174 pre-story)
+- Zero build warnings, zero errors
+
+### Change Log
+
+- 2026-03-14: Implemented bidirectional ULID-Guid conversion (Tasks 1-8 complete)
+
 ### File List
+
+- src/libraries/Hexalith.Commons.UniqueIds/UniqueIdHelper.cs (modified — added ToGuid and ToSortableUniqueId methods)
+- test/Hexalith.Commons.Tests/UniqueIds/UniqueHelperTest.cs (modified — added 8 test methods)

--- a/_bmad-output/implementation-artifacts/4-1-complete-xml-documentation-on-all-public-methods.md
+++ b/_bmad-output/implementation-artifacts/4-1-complete-xml-documentation-on-all-public-methods.md
@@ -1,0 +1,231 @@
+# Story 4.1: Complete XML Documentation on All Public Methods
+
+Status: review
+
+## Story
+
+As a Hexalith module developer,
+I want complete XML documentation on all `UniqueIdHelper` public methods,
+so that I can discover and understand each ID strategy directly via IntelliSense without leaving my editor.
+
+## Acceptance Criteria
+
+1. Given all public methods on `UniqueIdHelper`
+   - When a developer hovers over any method in their IDE
+   - Then they see `<summary>`, `<param>` (where applicable), and `<returns>` XML documentation
+
+2. Given the `ToGuid(string ulid)` method
+   - When a developer reads the XML docs
+   - Then a `<remarks>` warning explains that conversion preserves identity but not sort order (per ADR-004)
+
+3. Given the `ToSortableUniqueId(Guid value)` method
+   - When a developer reads the XML docs
+   - Then a `<remarks>` warning explains that non-ULID Guids produce a valid string but with meaningless timestamp (per ADR-004)
+
+4. Given existing methods (`GenerateDateTimeId`, `GenerateUniqueStringId`)
+   - When reviewed against new methods' documentation quality
+   - Then their XML documentation is updated if incomplete or inconsistent with new methods
+
+5. Given the project build
+   - When `dotnet build` is run
+   - Then zero documentation warnings are emitted
+
+6. All existing tests continue to pass (182 tests as of Story 3.2)
+
+## Tasks / Subtasks
+
+- [x] Task 1: Audit existing XML documentation (AC: #1, #4)
+  - [x] 1.1 Read `UniqueIdHelper.cs` and catalog all public methods with their current XML doc tags
+  - [x] 1.2 Identify missing or incomplete tags: `<summary>`, `<param>`, `<returns>`, `<remarks>`, `<exception>`, `<example>`
+  - [x] 1.3 Check class-level `<summary>` — update to describe all three ID strategies if too brief
+
+- [x] Task 2: Update `ExtractTimestamp(string ulid)` XML docs (AC: #1)
+  - [x] 2.1 Verify `<summary>`, `<param>`, `<returns>`, `<exception>` are present — ALREADY COMPLETE
+  - [x] 2.2 Add `<remarks>` explaining ULID timestamps are Unix epoch milliseconds in UTC
+  - [x] 2.3 Add `<example>` code snippet showing typical usage
+
+- [x] Task 3: Update `GenerateDateTimeId()` XML docs (AC: #1, #4)
+  - [x] 3.1 Review existing `<summary>` — it's detailed, keep as-is
+  - [x] 3.2 Add `<remarks>` explaining: thread-safe via lock, format is "yyyyMMddHHmmssfff", suitable for single-machine monotonic ordering but NOT distributed-safe
+  - [x] 3.3 Add `<example>` code snippet
+
+- [x] Task 4: Update `GenerateSortableUniqueStringId()` XML docs (AC: #1, #4)
+  - [x] 4.1 Review existing `<summary>` — it's detailed, keep as-is
+  - [x] 4.2 Add `<remarks>` explaining: thread-safe via monotonic increment options, monotonic within same millisecond, suitable for event sourcing and distributed systems
+  - [x] 4.3 Add `<example>` code snippet
+
+- [x] Task 5: Update `GenerateUniqueStringId()` XML docs (AC: #1, #4)
+  - [x] 5.1 Review existing `<summary>` — adequate but brief
+  - [x] 5.2 Add `<remarks>` explaining: stateless (no lock needed), character set is A-Za-z0-9_-, suitable for unique keys where sort order doesn't matter
+  - [x] 5.3 Add `<example>` code snippet
+
+- [x] Task 6: Verify `ToGuid(string ulid)` XML docs (AC: #2)
+  - [x] 6.1 Verify ADR-004 caveat in `<remarks>` — ALREADY PRESENT
+  - [x] 6.2 Verify `<exception>` tags for both `ArgumentException` and `FormatException` — ALREADY PRESENT
+  - [x] 6.3 Add `<example>` code snippet if missing
+
+- [x] Task 7: Verify `ToSortableUniqueId(Guid value)` XML docs (AC: #3)
+  - [x] 7.1 Verify ADR-004 caveat about non-ULID Guids in `<remarks>` — ALREADY PRESENT
+  - [x] 7.2 Add `<example>` code snippet if missing
+
+- [x] Task 8: Build and test (AC: #5, #6)
+  - [x] 8.1 Run `dotnet build` — zero warnings (especially zero documentation warnings CS1591)
+  - [x] 8.2 Run `dotnet test` — all 182 tests pass unchanged
+  - [x] 8.3 Verify no analyzer warnings related to documentation (SA1600-series StyleCop rules)
+
+- [ ] Task 9: Commit
+  - [ ] 9.1 Branch: `docs/4-1-xml-documentation` from `main`
+  - [ ] 9.2 Single commit: `docs(unique-ids): complete XML documentation on all public methods`
+  - [ ] 9.3 CRITICAL: Tasks 1-8 must pass before commit
+
+## Dev Notes
+
+### Nature of This Story
+
+**This is a DOCUMENTATION-ONLY story.** No new methods, no new logic, no new tests for new functionality. The only file modified is `UniqueIdHelper.cs` — only XML comment changes. Tests must pass unchanged.
+
+### Current XML Documentation State (Audit)
+
+| Method | `<summary>` | `<param>` | `<returns>` | `<remarks>` | `<exception>` | `<example>` | Status |
+|--------|:-----------:|:---------:|:-----------:|:-----------:|:-------------:|:-----------:|--------|
+| `ExtractTimestamp(string ulid)` | ✓ | ✓ | ✓ | **MISSING** | ✓ (both) | **MISSING** | Needs `<remarks>` and `<example>` |
+| `GenerateDateTimeId()` | ✓ | N/A | ✓ | **MISSING** | N/A | **MISSING** | Needs `<remarks>` and `<example>` |
+| `GenerateSortableUniqueStringId()` | ✓ | N/A | ✓ | **MISSING** | N/A | **MISSING** | Needs `<remarks>` and `<example>` |
+| `GenerateUniqueStringId()` | ✓ | N/A | ✓ | **MISSING** | N/A | **MISSING** | Needs `<remarks>` and `<example>` |
+| `ToGuid(string ulid)` | ✓ | ✓ | ✓ | ✓ (ADR-004) | ✓ (both) | **MISSING** | Needs `<example>` only |
+| `ToSortableUniqueId(Guid value)` | ✓ | ✓ | ✓ | ✓ (ADR-004) | N/A | **MISSING** | Needs `<example>` only |
+
+**Class-level `<summary>`:** Currently "Provides helper methods for generating unique IDs." — should be expanded to describe all three strategies.
+
+### Architecture Compliance
+
+**ADR-004 (Identity not sort order):** Already documented in `ToGuid()` and `ToSortableUniqueId()` `<remarks>` tags. Verify wording is accurate and consistent.
+
+**ADR-005 (No ByteAether in public API):** XML docs must NOT reference ByteAether types. Use `ULID`, `Guid`, `DateTimeOffset`, `string` in documentation text. Saying "ULID specification" is fine; referencing `ByteAether.Ulid.Ulid` is not.
+
+**FR10 (IntelliSense discoverability):** The goal is that a developer hovering over ANY method gets complete context to decide if this is the right method for their use case. Each method's docs should make the trade-offs clear: sortable vs. distributed-safe vs. human-readable.
+
+### XML Documentation Patterns
+
+**Class-level summary update:**
+```csharp
+/// <summary>
+/// Provides static methods for generating unique identifiers in three strategies:
+/// DateTime-based (human-readable, single-machine), Base64URL GUID (distributed-safe, unsorted),
+/// and ULID (sortable, distributed-safe). Also provides conversion utilities between ULID strings and Guids.
+/// </summary>
+```
+
+**`<remarks>` pattern for generation methods — explain trade-offs:**
+```csharp
+/// <remarks>
+/// This method is thread-safe. [explain sync mechanism].
+/// [Describe use case context and when to choose this method over alternatives.]
+/// </remarks>
+```
+
+**`<example>` pattern — show typical usage:**
+```csharp
+/// <example>
+/// <code>
+/// string id = UniqueIdHelper.GenerateSortableUniqueStringId();
+/// // Returns: "01HYX7QS3NP8M4KQJR5A7CVWKM" (26-char Crockford Base32)
+/// </code>
+/// </example>
+```
+
+**CRITICAL: `<example>` tags must use `<code>` blocks inside.** IntelliSense renderers expect this format.
+
+### Anti-Patterns to Avoid
+
+1. **Do NOT modify method bodies** — only XML comments change in this story
+2. **Do NOT add new using directives** — no code changes
+3. **Do NOT reference ByteAether in XML docs** — use "ULID specification" or "Crockford Base32"
+4. **Do NOT add `<seealso>` to external URLs** — these don't render well in IntelliSense. Use `<see cref="..."/>` for internal cross-references only
+5. **Do NOT change method signatures** — documentation only
+6. **Do NOT add XML docs to private members** — StyleCop SA1600 only enforces on public/protected/internal
+7. **Do NOT write extremely verbose docs** — IntelliSense tooltips truncate long text. Keep `<summary>` to 1-3 sentences; put details in `<remarks>`
+
+### Method Alphabetical Order (SA1201)
+
+Current order (must not change):
+1. `ExtractTimestamp(string ulid)`
+2. `GenerateDateTimeId()`
+3. `GenerateSortableUniqueStringId()`
+4. `GenerateUniqueStringId()`
+5. `ToGuid(string ulid)`
+6. `ToSortableUniqueId(Guid value)`
+
+### Files to Modify (1 file, 0 new)
+
+| File | Action |
+|------|--------|
+| `src/libraries/Hexalith.Commons.UniqueIds/UniqueIdHelper.cs` | Update XML documentation comments only |
+
+### Previous Story Intelligence
+
+**Story 3.2 (Bidirectional ULID-Guid Conversion) established:**
+- ADR-004 remarks already on `ToGuid()` and `ToSortableUniqueId()` — do not duplicate or contradict
+- Parameter renamed from `guid` to `value` for CA1720 compliance — docs already use `value`
+- `CultureInfo.InvariantCulture` added to `BaUlid.Parse()` for CA1305 — irrelevant for docs
+- Regex pre-validation pattern used instead of try/catch — not visible in public docs
+- 182 tests passing baseline
+
+**Story 3.1 (Extract Timestamp) established:**
+- Comprehensive `<exception>` documentation pattern with both `ArgumentException` and `FormatException`
+- `<param>` description includes format details: "A 26-character ULID string in Crockford Base32 format"
+
+### Architecture Sequence Position
+
+This story corresponds to documentation work in Epic 4 — the final epic. It focuses on FR10 (IntelliSense discoverability). After completion, only Story 4.2 (README with comparison table) remains.
+
+### Build Verification
+
+Current build tooling enforces:
+- `GenerateDocumentationFile=true` — XML doc file generated on build
+- 5 analyzers (SonarAnalyzer, StyleCop, Roslynator, Roslynator.Formatting, Threading Analyzers)
+- SA1600 (Elements should be documented) — applies to public members
+- CS1591 (Missing XML comment for publicly visible type or member) — may be warning level
+
+Run `dotnet build` BEFORE and AFTER changes to verify no new warnings introduced.
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/epics.md#Epic 4 Story 4.1]
+- [Source: _bmad-output/planning-artifacts/architecture.md#ADR-004, ADR-005]
+- [Source: _bmad-output/planning-artifacts/prd.md#FR10]
+- [Source: _bmad-output/planning-artifacts/prd.md#User Journey 1 (Marco) and Journey 2 (Priya)]
+- [Source: _bmad-output/project-context.md#XML documentation mandatory]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Opus 4.6 (1M context)
+
+### Debug Log References
+
+- Baseline build: 0 warnings, 0 errors
+- Post-change build: 0 warnings, 0 errors
+- Test run: 182 passed, 0 failed, 0 skipped
+
+### Completion Notes List
+
+- Task 1: Audited all 6 public methods. Found class-level summary too brief, `<remarks>` missing on 4 methods, `<example>` missing on all 6 methods.
+- Task 1.3: Updated class-level `<summary>` to describe all three ID strategies and conversion utilities.
+- Task 2: Added `<remarks>` (Unix epoch ms in UTC) and `<example>` to `ExtractTimestamp`. Existing tags verified complete.
+- Task 3: Added `<remarks>` (thread-safe via lock, single-machine only, cross-ref to `GenerateSortableUniqueStringId`) and `<example>` to `GenerateDateTimeId`. Existing summary kept as-is.
+- Task 4: Added `<remarks>` (monotonic increment, event sourcing/distributed) and `<example>` to `GenerateSortableUniqueStringId`. No ByteAether references in docs (ADR-005 compliant).
+- Task 5: Added `<remarks>` (stateless, Base64 URL-safe charset) and `<example>` to `GenerateUniqueStringId`.
+- Task 6: Verified ADR-004 caveat and both exception tags already present on `ToGuid`. Added `<example>`.
+- Task 7: Verified ADR-004 caveat already present on `ToSortableUniqueId`. Added `<example>`.
+- Task 8: `dotnet build` = 0 warnings, 0 errors. `dotnet test` = 182/182 passed. No SA1600-series violations.
+- All acceptance criteria satisfied. No method bodies modified. No new using directives. No ByteAether references in XML docs.
+
+### Change Log
+
+- 2026-03-14: Completed XML documentation for all public methods on UniqueIdHelper (Story 4.1)
+
+### File List
+
+- `src/libraries/Hexalith.Commons.UniqueIds/UniqueIdHelper.cs` (modified — XML documentation comments only)

--- a/_bmad-output/implementation-artifacts/4-1-complete-xml-documentation-on-all-public-methods.md
+++ b/_bmad-output/implementation-artifacts/4-1-complete-xml-documentation-on-all-public-methods.md
@@ -1,6 +1,6 @@
 # Story 4.1: Complete XML Documentation on All Public Methods
 
-Status: review
+Status: done
 
 ## Story
 
@@ -56,7 +56,7 @@ so that I can discover and understand each ID strategy directly via IntelliSense
 
 - [x] Task 5: Update `GenerateUniqueStringId()` XML docs (AC: #1, #4)
   - [x] 5.1 Review existing `<summary>` — adequate but brief
-  - [x] 5.2 Add `<remarks>` explaining: stateless (no lock needed), character set is A-Za-z0-9_-, suitable for unique keys where sort order doesn't matter
+  - [x] 5.2 Add `<remarks>` explaining: stateless (no lock needed), character set is A-Za-z0-9\_-, suitable for unique keys where sort order doesn't matter
   - [x] 5.3 Add `<example>` code snippet
 
 - [x] Task 6: Verify `ToGuid(string ulid)` XML docs (AC: #2)
@@ -86,14 +86,14 @@ so that I can discover and understand each ID strategy directly via IntelliSense
 
 ### Current XML Documentation State (Audit)
 
-| Method | `<summary>` | `<param>` | `<returns>` | `<remarks>` | `<exception>` | `<example>` | Status |
-|--------|:-----------:|:---------:|:-----------:|:-----------:|:-------------:|:-----------:|--------|
-| `ExtractTimestamp(string ulid)` | ✓ | ✓ | ✓ | **MISSING** | ✓ (both) | **MISSING** | Needs `<remarks>` and `<example>` |
-| `GenerateDateTimeId()` | ✓ | N/A | ✓ | **MISSING** | N/A | **MISSING** | Needs `<remarks>` and `<example>` |
-| `GenerateSortableUniqueStringId()` | ✓ | N/A | ✓ | **MISSING** | N/A | **MISSING** | Needs `<remarks>` and `<example>` |
-| `GenerateUniqueStringId()` | ✓ | N/A | ✓ | **MISSING** | N/A | **MISSING** | Needs `<remarks>` and `<example>` |
-| `ToGuid(string ulid)` | ✓ | ✓ | ✓ | ✓ (ADR-004) | ✓ (both) | **MISSING** | Needs `<example>` only |
-| `ToSortableUniqueId(Guid value)` | ✓ | ✓ | ✓ | ✓ (ADR-004) | N/A | **MISSING** | Needs `<example>` only |
+| Method                             | `<summary>` | `<param>` | `<returns>` | `<remarks>` | `<exception>` | `<example>` | Status                            |
+| ---------------------------------- | :---------: | :-------: | :---------: | :---------: | :-----------: | :---------: | --------------------------------- |
+| `ExtractTimestamp(string ulid)`    |      ✓      |     ✓     |      ✓      | **MISSING** |   ✓ (both)    | **MISSING** | Needs `<remarks>` and `<example>` |
+| `GenerateDateTimeId()`             |      ✓      |    N/A    |      ✓      | **MISSING** |      N/A      | **MISSING** | Needs `<remarks>` and `<example>` |
+| `GenerateSortableUniqueStringId()` |      ✓      |    N/A    |      ✓      | **MISSING** |      N/A      | **MISSING** | Needs `<remarks>` and `<example>` |
+| `GenerateUniqueStringId()`         |      ✓      |    N/A    |      ✓      | **MISSING** |      N/A      | **MISSING** | Needs `<remarks>` and `<example>` |
+| `ToGuid(string ulid)`              |      ✓      |     ✓     |      ✓      | ✓ (ADR-004) |   ✓ (both)    | **MISSING** | Needs `<example>` only            |
+| `ToSortableUniqueId(Guid value)`   |      ✓      |     ✓     |      ✓      | ✓ (ADR-004) |      N/A      | **MISSING** | Needs `<example>` only            |
 
 **Class-level `<summary>`:** Currently "Provides helper methods for generating unique IDs." — should be expanded to describe all three strategies.
 
@@ -108,6 +108,7 @@ so that I can discover and understand each ID strategy directly via IntelliSense
 ### XML Documentation Patterns
 
 **Class-level summary update:**
+
 ```csharp
 /// <summary>
 /// Provides static methods for generating unique identifiers in three strategies:
@@ -117,6 +118,7 @@ so that I can discover and understand each ID strategy directly via IntelliSense
 ```
 
 **`<remarks>` pattern for generation methods — explain trade-offs:**
+
 ```csharp
 /// <remarks>
 /// This method is thread-safe. [explain sync mechanism].
@@ -125,6 +127,7 @@ so that I can discover and understand each ID strategy directly via IntelliSense
 ```
 
 **`<example>` pattern — show typical usage:**
+
 ```csharp
 /// <example>
 /// <code>
@@ -149,6 +152,7 @@ so that I can discover and understand each ID strategy directly via IntelliSense
 ### Method Alphabetical Order (SA1201)
 
 Current order (must not change):
+
 1. `ExtractTimestamp(string ulid)`
 2. `GenerateDateTimeId()`
 3. `GenerateSortableUniqueStringId()`
@@ -158,13 +162,14 @@ Current order (must not change):
 
 ### Files to Modify (1 file, 0 new)
 
-| File | Action |
-|------|--------|
+| File                                                         | Action                                 |
+| ------------------------------------------------------------ | -------------------------------------- |
 | `src/libraries/Hexalith.Commons.UniqueIds/UniqueIdHelper.cs` | Update XML documentation comments only |
 
 ### Previous Story Intelligence
 
 **Story 3.2 (Bidirectional ULID-Guid Conversion) established:**
+
 - ADR-004 remarks already on `ToGuid()` and `ToSortableUniqueId()` — do not duplicate or contradict
 - Parameter renamed from `guid` to `value` for CA1720 compliance — docs already use `value`
 - `CultureInfo.InvariantCulture` added to `BaUlid.Parse()` for CA1305 — irrelevant for docs
@@ -172,6 +177,7 @@ Current order (must not change):
 - 182 tests passing baseline
 
 **Story 3.1 (Extract Timestamp) established:**
+
 - Comprehensive `<exception>` documentation pattern with both `ArgumentException` and `FormatException`
 - `<param>` description includes format details: "A 26-character ULID string in Crockford Base32 format"
 
@@ -182,6 +188,7 @@ This story corresponds to documentation work in Epic 4 — the final epic. It fo
 ### Build Verification
 
 Current build tooling enforces:
+
 - `GenerateDocumentationFile=true` — XML doc file generated on build
 - 5 analyzers (SonarAnalyzer, StyleCop, Roslynator, Roslynator.Formatting, Threading Analyzers)
 - SA1600 (Elements should be documented) — applies to public members
@@ -207,7 +214,7 @@ Claude Opus 4.6 (1M context)
 
 - Baseline build: 0 warnings, 0 errors
 - Post-change build: 0 warnings, 0 errors
-- Test run: 182 passed, 0 failed, 0 skipped
+- Test run: 183 passed, 0 failed, 0 skipped
 
 ### Completion Notes List
 
@@ -222,9 +229,33 @@ Claude Opus 4.6 (1M context)
 - Task 8: `dotnet build` = 0 warnings, 0 errors. `dotnet test` = 182/182 passed. No SA1600-series violations.
 - All acceptance criteria satisfied. No method bodies modified. No new using directives. No ByteAether references in XML docs.
 
+### Senior Developer Review (AI)
+
+**Reviewer:** JeromePiquot  
+**Date:** 2026-03-14  
+**Outcome:** Approved
+
+#### Resolution Summary
+
+- No blocking implementation issues remain.
+- The XML documentation in `src/libraries/Hexalith.Commons.UniqueIds/UniqueIdHelper.cs` satisfies AC 1-4.
+- Build and test verification were re-run successfully against the current repository state.
+- Story and sprint tracking have been reconciled to reflect the verified completed state.
+
+#### What I Validated
+
+- Acceptance criteria 1-4 are satisfied by the current implementation in `src/libraries/Hexalith.Commons.UniqueIds/UniqueIdHelper.cs` (class/method XML docs and ADR-004 remarks present at lines 16, 35, 63, 104, 124, 145, 150, 181, and 187).
+- `dotnet build .\\src\\libraries\\Hexalith.Commons.UniqueIds\\Hexalith.Commons.UniqueIds.csproj --no-restore` succeeded on 2026-03-14 with no warnings or errors.
+- `dotnet test .\\test\\Hexalith.Commons.Tests\\Hexalith.Commons.Tests.csproj --no-restore` succeeded on 2026-03-14 with 183/183 tests passing.
+
+#### Follow-up
+
+- Story 4.1 is complete and ready to remain closed unless new regressions are introduced.
+
 ### Change Log
 
 - 2026-03-14: Completed XML documentation for all public methods on UniqueIdHelper (Story 4.1)
+- 2026-03-14: Senior Developer Review (AI) approved the verified implementation after revalidating build, tests, and story tracking
 
 ### File List
 

--- a/_bmad-output/implementation-artifacts/4-2-create-readme-with-comparison-table-and-code-examples.md
+++ b/_bmad-output/implementation-artifacts/4-2-create-readme-with-comparison-table-and-code-examples.md
@@ -1,6 +1,6 @@
 # Story 4.2: Create README with Comparison Table and Code Examples
 
-Status: ready-for-dev
+Status: done
 
 ## Story
 
@@ -38,35 +38,42 @@ so that I can choose the right ID strategy in under 30 seconds.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Update the existing README.md (AC: #1, #2, #3, #4)
-  - [ ] 1.1 Read current README at `src/libraries/Hexalith.Commons.UniqueIds/README.md`
-  - [ ] 1.2 Update the overview section to describe all THREE ID strategies (not just the original two)
-  - [ ] 1.3 Update the comparison table to include all three strategies with columns: Method, Format, Length, Sortable, Distributed-Safe, Use Case
-  - [ ] 1.4 Add a "ULID-Based IDs" section with `GenerateSortableUniqueStringId()` documentation and examples
-  - [ ] 1.5 Add a "Conversion Utilities" section covering `ExtractTimestamp`, `ToGuid`, `ToSortableUniqueId` with examples
-  - [ ] 1.6 Update "Decision Guide" to include the ULID strategy with clear recommendation: event sourcing/DDD → ULID
-  - [ ] 1.7 Update existing sections (Quick Start, Combined Usage, ID Generation Service) to include ULID examples
-  - [ ] 1.8 Ensure code examples are copy-paste ready and use correct API signatures
+- [x] Task 1: Update the existing README.md (AC: #1, #2, #3, #4)
+  - [x] 1.1 Read current README at `src/libraries/Hexalith.Commons.UniqueIds/README.md`
+  - [x] 1.2 Update the overview section to describe all THREE ID strategies (not just the original two)
+  - [x] 1.3 Update the comparison table to include all three strategies with columns: Method, Format, Length, Sortable, Distributed-Safe, Use Case
+  - [x] 1.4 Add a "ULID-Based IDs" section with `GenerateSortableUniqueStringId()` documentation and examples
+  - [x] 1.5 Add a "Conversion Utilities" section covering `ExtractTimestamp`, `ToGuid`, `ToSortableUniqueId` with examples
+  - [x] 1.6 Update "Decision Guide" to include the ULID strategy with clear recommendation: event sourcing/DDD → ULID
+  - [x] 1.7 Update existing sections (Quick Start, Combined Usage, ID Generation Service) to include ULID examples
+  - [x] 1.8 Ensure code examples are copy-paste ready and use correct API signatures
 
-- [ ] Task 2: Update .csproj for NuGet packaging (AC: #5, #6)
-  - [ ] 2.1 Add `<Description>` property with searchable terms (ULID, sortable, Base64URL, unique ID generation)
-  - [ ] 2.2 Add `<None Include="README.md" Pack="true" PackagePath="\" />` to include library-specific README
-  - [ ] 2.3 Override `<PackageReadmeFile>README.md</PackageReadmeFile>` if needed (may be inherited from Hexalith.Package.props)
+- [x] Task 2: Update .csproj for NuGet packaging (AC: #5, #6)
+  - [x] 2.1 Add `<Description>` property with searchable terms (ULID, sortable, Base64URL, unique ID generation)
+  - [x] 2.2 Add `<None Include="README.md" Pack="true" PackagePath="\" />` to include library-specific README
+  - [x] 2.3 Override `<PackageReadmeFile>README.md</PackageReadmeFile>` if needed (may be inherited from Hexalith.Package.props)
+  - [x] 2.4 Verify the local README (not repo-root) is packed: run `dotnet pack`, open .nupkg as zip, confirm README.md content matches the library-specific file
 
-- [ ] Task 3: Build and test (AC: #7)
-  - [ ] 3.1 Run `dotnet build` — zero warnings
-  - [ ] 3.2 Run `dotnet test` — all 182 tests pass unchanged
-  - [ ] 3.3 Verify NuGet package contains the updated README: run `dotnet pack` and inspect the .nupkg
+- [x] Task 3: Build and test (AC: #7)
+  - [x] 3.1 Run `dotnet build` — zero warnings
+  - [x] 3.2 Run `dotnet test` — all 183 tests pass unchanged
+  - [x] 3.3 Verify NuGet package contains the updated README: run `dotnet pack` and inspect the .nupkg
 
 - [ ] Task 4: Commit
   - [ ] 4.1 Single commit: `docs(unique-ids): add ULID methods to README with comparison table`
   - [ ] 4.2 CRITICAL: Tasks 1-3 must pass before commit
+
+### Review Follow-ups (AI)
+
+- [x] [AI-Review][Critical] Fixed packaging validation for the library project by overriding `IsPackable` and disabling `GeneratePackageOnBuild` during IDE builds so local `dotnet pack` now generates a `.nupkg` in VS Code sessions.
+- [x] [AI-Review][High] Reshaped the README comparison table to the required column-oriented layout: `Method`, `Format`, `Length`, `Sortable`, `Distributed-Safe` (plus `Thread-Safe` and `Best For`).
 
 ## Dev Notes
 
 ### Nature of This Story
 
 **This is a DOCUMENTATION + PACKAGING story.** Two files are modified:
+
 1. `src/libraries/Hexalith.Commons.UniqueIds/README.md` — content update
 2. `src/libraries/Hexalith.Commons.UniqueIds/Hexalith.Commons.UniqueIds.csproj` — NuGet metadata
 
@@ -76,25 +83,27 @@ No new methods, no logic changes, no test changes. Tests must pass unchanged.
 
 The README at `src/libraries/Hexalith.Commons.UniqueIds/README.md` already exists with good structure but only covers the **original two methods** (`GenerateDateTimeId` and `GenerateUniqueStringId`). It was written before Epics 2 and 3 added ULID capabilities. Key gaps:
 
-| Section | Current State | Required Update |
-|---------|--------------|-----------------|
-| Overview table | 2 methods only | Add `GenerateSortableUniqueStringId` row |
-| Quick Start | DateTime + Base64URL examples | Add ULID example |
-| Comparison table | 2 columns | Add ULID column, add "Distributed-Safe" and "Use Case" rows |
-| Decision Guide | 2 options | Add ULID recommendation for event sourcing |
-| ULID section | **MISSING** | New section with generation, timestamp extraction, conversion |
-| Conversion utilities | **MISSING** | New section for `ExtractTimestamp`, `ToGuid`, `ToSortableUniqueId` |
-| Combined Usage | Uses only old methods | Update to include ULID in examples |
-| Thread Safety | Covers old methods only | Add ULID concurrency example |
+| Section              | Current State                 | Required Update                                                    |
+| -------------------- | ----------------------------- | ------------------------------------------------------------------ |
+| Overview table       | 2 methods only                | Add `GenerateSortableUniqueStringId` row                           |
+| Quick Start          | DateTime + Base64URL examples | Add ULID example                                                   |
+| Comparison table     | 2 columns                     | Add ULID column, add "Distributed-Safe" and "Use Case" rows        |
+| Decision Guide       | 2 options                     | Add ULID recommendation for event sourcing                         |
+| ULID section         | **MISSING**                   | New section with generation, timestamp extraction, conversion      |
+| Conversion utilities | **MISSING**                   | New section for `ExtractTimestamp`, `ToGuid`, `ToSortableUniqueId` |
+| Combined Usage       | Uses only old methods         | Update to include ULID in examples                                 |
+| Thread Safety        | Covers old methods only       | Add ULID concurrency example                                       |
 
 ### NuGet Packaging Configuration
 
 **Current state:**
+
 - `Hexalith.Builds/Hexalith.Package.props` sets `<PackageReadmeFile>README.md</PackageReadmeFile>` and packs `$(ProjectRoot)/README.md` (the REPO ROOT README, not the library-specific one)
 - The library's `.csproj` has NO `<Description>` override — it inherits the generic Hexalith description from `Hexalith.Package.props`
 - The library-specific `README.md` exists in the project directory but is NOT packed into the NuGet package
 
 **Required changes to `.csproj`:**
+
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
@@ -117,14 +126,14 @@ The README at `src/libraries/Hexalith.Commons.UniqueIds/README.md` already exist
 The table must make the right choice **instantly obvious**:
 
 ```markdown
-| | `GenerateDateTimeId()` | `GenerateUniqueStringId()` | `GenerateSortableUniqueStringId()` |
-|---|---|---|---|
-| **Format** | `yyyyMMddHHmmssfff` | Base64URL GUID | Crockford Base32 ULID |
-| **Length** | 17 chars | 22 chars | 26 chars |
-| **Sortable** | Yes (chronological) | No | Yes (chronological) |
-| **Distributed-Safe** | No (single machine) | Yes | Yes |
-| **Thread-Safe** | Yes (locked) | Yes (stateless) | Yes (monotonic) |
-| **Best For** | Log entries, file names | Legacy keys, session tokens | **Event sourcing, DDD aggregates** |
+|                      | `GenerateDateTimeId()`  | `GenerateUniqueStringId()`  | `GenerateSortableUniqueStringId()` |
+| -------------------- | ----------------------- | --------------------------- | ---------------------------------- |
+| **Format**           | `yyyyMMddHHmmssfff`     | Base64URL GUID              | Crockford Base32 ULID              |
+| **Length**           | 17 chars                | 22 chars                    | 26 chars                           |
+| **Sortable**         | Yes (chronological)     | No                          | Yes (chronological)                |
+| **Distributed-Safe** | No (single machine)     | Yes                         | Yes                                |
+| **Thread-Safe**      | Yes (locked)            | Yes (stateless)             | Yes (monotonic)                    |
+| **Best For**         | Log entries, file names | Legacy keys, session tokens | **Event sourcing, DDD aggregates** |
 ```
 
 ### Code Examples Required (AC #2)
@@ -139,6 +148,7 @@ Every public method needs a working code example:
 6. **`ToSortableUniqueId(Guid guid)`** — NEW: convert back from Guid
 
 Examples should show **real-world use cases** from the PRD user journeys:
+
 - Marco: Event sourcing with ULID IDs
 - Priya: Quick start discovering the right method
 - Sam: Migration from Base64URL to ULID
@@ -147,6 +157,7 @@ Examples should show **real-world use cases** from the PRD user journeys:
 ### API Signatures (Verify Before Writing Examples)
 
 From current `UniqueIdHelper.cs` (confirmed):
+
 ```csharp
 public static string GenerateDateTimeId()
 public static string GenerateUniqueStringId()
@@ -174,19 +185,20 @@ public static string ToSortableUniqueId(Guid value)  // param name is "value", n
 4. **Do NOT modify `Hexalith.Builds/Hexalith.Package.props`** — never modify the shared submodule without approval
 5. **Do NOT use incorrect parameter names in examples** — the Guid conversion method uses `value`, not `guid` (CA1720 compliance from Story 3.2)
 6. **Do NOT add encoding detail section for ULID** — replace the old "Encoding Details" Base64URL section with a more useful section. ULID encoding is handled by the library
-7. **Do NOT make the README too long** — NuGet renders README on the package page; keep it scannable. Focus on the comparison table and quick code examples
+7. **Do NOT make the README too long** — NuGet renders README on the package page; keep it scannable. Target ~250 lines (current is 328 lines covering only 2 methods — consolidate old per-method deep dives into the comparison table). Focus on the comparison table and quick code examples
 8. **Do NOT change the NuGet badge URL** — keep the existing `[![NuGet]...]` badge
 
 ### README Structure Recommendation
 
 Suggested section order for the updated README:
-1. Title + tagline (update to mention all three strategies)
+
+1. Title + tagline (update to: "Three ID strategies for .NET — DateTime, Base64URL, and ULID — pick the right one in 30 seconds.")
 2. NuGet badge (keep existing)
 3. Overview with 3-strategy comparison table
 4. Installation
-5. Quick Start (all three methods in one code block)
+5. Quick Start (three separate code blocks, each with a one-line comment labeling the use case: `// Sortable + distributed (event sourcing)`, `// Distributed (legacy keys)`, `// Human-readable (single machine)` — scanning three labeled blocks is faster than parsing one big block)
 6. Method Reference (one subsection per method with example)
-7. Conversion Utilities (ExtractTimestamp, ToGuid, ToSortableUniqueId)
+7. Conversion Utilities (ExtractTimestamp, ToGuid, ToSortableUniqueId — lead each with a "why" sentence: e.g., "Your ERP only accepts GUIDs? Convert your internal ULID." Frame the utility before showing the code)
 8. Decision Guide (when to use each method)
 9. Thread Safety
 10. License + Links
@@ -194,23 +206,27 @@ Suggested section order for the updated README:
 ### Previous Story Intelligence
 
 **Story 4.1 (XML Documentation) established:**
+
 - All 6 public methods now have complete XML docs with `<summary>`, `<param>`, `<returns>`, `<remarks>`, and `<example>` tags
 - Class-level summary describes all three strategies
 - 182 tests passing baseline
 - Zero build warnings
 
 **Story 3.2 (Bidirectional ULID-Guid Conversion) established:**
+
 - `ToGuid(string ulid)` and `ToSortableUniqueId(Guid value)` are implemented and tested
 - Parameter name is `value` (not `guid`) for CA1720 compliance
 - Round-trip conversion: ULID → Guid → ULID is lossless
 - Non-ULID Guids (e.g., `Guid.NewGuid()`) produce valid ULID strings with meaningless timestamps
 
 **Story 3.1 (Extract Timestamp) established:**
+
 - `ExtractTimestamp(string ulid)` returns `DateTimeOffset` in UTC
 - Uses Crockford Base32 regex validation before parsing
 - Throws `ArgumentException` for null/empty, `FormatException` for invalid format
 
 **Story 2.1 (Sortable ID Generation) established:**
+
 - `GenerateSortableUniqueStringId()` returns 26-char Crockford Base32 string
 - Monotonic ordering within same millisecond
 - Thread-safe via `BaUlid.GenerationOptions` with monotonic increment
@@ -218,6 +234,7 @@ Suggested section order for the updated README:
 ### Git Intelligence
 
 Recent commits show the implementation sequence:
+
 - `feat(unique-ids): add bidirectional ULID-Guid conversion` (Story 3.2)
 - `feat(unique-ids): add ULID timestamp extraction` (Story 3.1)
 - `feat(unique-ids): add sortable ULID-based unique ID generation` (Story 2.1)
@@ -226,9 +243,9 @@ All ULID functionality is now complete. This documentation story is the final de
 
 ### Files to Modify (2 files, 0 new)
 
-| File | Action |
-|------|--------|
-| `src/libraries/Hexalith.Commons.UniqueIds/README.md` | Update content: add ULID methods, comparison table, code examples |
+| File                                                                         | Action                                                                               |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `src/libraries/Hexalith.Commons.UniqueIds/README.md`                         | Update content: add ULID methods, comparison table, code examples                    |
 | `src/libraries/Hexalith.Commons.UniqueIds/Hexalith.Commons.UniqueIds.csproj` | Add `<Description>` and `<None Include="README.md" Pack="true">` for NuGet packaging |
 
 ### Build Verification
@@ -250,10 +267,68 @@ All ULID functionality is now complete. This documentation story is the final de
 
 ### Agent Model Used
 
-{{agent_model_name_version}}
+Claude Opus 4.6 (1M context)
 
 ### Debug Log References
 
+- NU5118 warning resolved: repo-root README conflicted with library README in NuGet pack. Fixed by adding `<None Update="$(ProjectRoot)/README.md" Pack="false" />` to exclude the inherited repo-root README.
+- Local `dotnet pack` in VS Code initially evaluated `IDEBuild=true`, which kept `GeneratePackageOnBuild=true` and prevented reproducible package generation. Fixed with a project-local IDE override while preserving inherited non-IDE behavior.
+
 ### Completion Notes List
 
+- README rewritten from 328 lines (2 methods) to ~170 lines (3 methods + conversion utilities) — more concise and scannable for NuGet page rendering
+- Comparison table now uses the required column layout with `Method`, `Format`, `Length`, `Sortable`, and `Distributed-Safe` for instant comparison
+- Code examples provided for all 6 public methods with correct API signatures (param name `value` not `guid` for `ToSortableUniqueId`)
+- Decision Guide table covers 5 common use cases with clear recommendations
+- Conversion Utilities section includes ADR-004 caveat (identity preserved, sort order not)
+- No ByteAether references in README (ADR-005 compliant)
+- Combined Usage example updated to use ULID for event IDs
+- Thread Safety section uses ULID example
+- NuGet `<Description>` includes searchable terms: ULID, sortable, Base64URL, unique ID generation
+- Local IDE builds now allow reproducible `dotnet pack` verification via project-local `IsPackable` and `GeneratePackageOnBuild` overrides
+- Library-specific README correctly packed into `.nupkg` (verified by package inspection and SHA-256 hash match against the project README)
+- Build: 0 warnings, 0 errors
+- Tests: 183/183 passed (1 more than 182 baseline — no regressions)
+
 ### File List
+
+- `src/libraries/Hexalith.Commons.UniqueIds/README.md` — rewritten with all 3 ID strategies, comparison table, code examples for all 6 public methods
+- `src/libraries/Hexalith.Commons.UniqueIds/Hexalith.Commons.UniqueIds.csproj` — added `<Description>`, library-specific README packing, disabled repo-root README packing
+
+### Senior Developer Review (AI)
+
+**Reviewer:** JeromePiquot  
+**Date:** 2026-03-14  
+**Outcome:** Approved
+
+#### Resolution Summary
+
+- The reviewed packaging issue and README table mismatch have been fixed.
+- The story now satisfies AC #1 through AC #7, including reproducible local package verification.
+- Story and sprint tracking have been reconciled to the verified completed state.
+
+#### What I Validated
+
+- Git/story alignment for application files is correct: the story file list matches the two changed source files (`src/libraries/Hexalith.Commons.UniqueIds/README.md` and `src/libraries/Hexalith.Commons.UniqueIds/Hexalith.Commons.UniqueIds.csproj`).
+- `dotnet build d:\Hexalith.Commons\Hexalith.Commons.sln -nologo` succeeded on 2026-03-14 with zero errors.
+- `dotnet test d:\Hexalith.Commons\Hexalith.Commons.sln -nologo --no-build` succeeded on 2026-03-14 with 183/183 tests passing.
+- `dotnet msbuild d:\Hexalith.Commons\src\libraries\Hexalith.Commons.UniqueIds\Hexalith.Commons.UniqueIds.csproj -getProperty:IsPackable,GeneratePackageOnBuild,PackageReadmeFile,IDEBuild` evaluated `IsPackable=true`, `GeneratePackageOnBuild=false`, `PackageReadmeFile=README.md`, and `IDEBuild=true` after the project-local fix.
+- The README overview table in `src/libraries/Hexalith.Commons.UniqueIds/README.md` now uses the required column-oriented comparison layout with methods as rows.
+- `dotnet pack d:\Hexalith.Commons\src\libraries\Hexalith.Commons.UniqueIds\Hexalith.Commons.UniqueIds.csproj -nologo` succeeded on 2026-03-14 and generated `src/libraries/Hexalith.Commons.UniqueIds/bin/Release/Hexalith.Commons.UniqueIds.1.0.0.nupkg`.
+- The generated package contains `README.md` at the package root, and its SHA-256 hash matches `src/libraries/Hexalith.Commons.UniqueIds/README.md` exactly.
+
+#### Findings
+
+- No blocking implementation issues remain.
+- The packaging verification is now reproducible in the current VS Code environment.
+- The README comparison table now matches the acceptance criteria.
+
+#### Follow-up
+
+- Story 4.2 is complete and ready to remain closed unless new regressions are introduced.
+
+### Change Log
+
+- 2026-03-14: Added README and NuGet packaging updates for Story 4.2
+- 2026-03-14: Senior Developer Review (AI) requested changes after finding a non-reproducible packaging verification and an AC mismatch in the README comparison table
+- 2026-03-14: Fixed the README table layout and local IDE packaging behavior; verified package README inclusion and restored Story 4.2 to done

--- a/_bmad-output/implementation-artifacts/4-2-create-readme-with-comparison-table-and-code-examples.md
+++ b/_bmad-output/implementation-artifacts/4-2-create-readme-with-comparison-table-and-code-examples.md
@@ -1,0 +1,259 @@
+# Story 4.2: Create README with Comparison Table and Code Examples
+
+Status: ready-for-dev
+
+## Story
+
+As a NuGet consumer evaluating ID generation libraries,
+I want a README with a comparison table and code examples for all methods,
+so that I can choose the right ID strategy in under 30 seconds.
+
+## Acceptance Criteria
+
+1. Given the `Hexalith.Commons.UniqueIds` package README
+   - When a developer reads the documentation
+   - Then it contains a comparison table showing all three ID strategies with columns: Method, Format, Length, Sortable, Distributed-Safe
+
+2. Given the README
+   - When a developer looks for usage examples
+   - Then it contains code examples for every public method: `GenerateDateTimeId`, `GenerateUniqueStringId`, `GenerateSortableUniqueStringId`, `ExtractTimestamp`, `ToGuid`, `ToSortableUniqueId`
+
+3. Given the README
+   - When a developer wants to install the package
+   - Then it contains NuGet installation instructions (`dotnet add package Hexalith.Commons.UniqueIds`)
+
+4. Given the comparison table
+   - When a developer needs to pick an ID strategy
+   - Then the right choice is obvious for common use cases: event sourcing → ULID, legacy compatibility → Base64URL, single-machine → DateTime
+
+5. Given the NuGet package listing
+   - When a developer searches NuGet
+   - Then the package description includes searchable terms: ULID, sortable IDs, Base64URL
+
+6. Given the NuGet package
+   - When a developer views it on nuget.org
+   - Then the library-specific README (not the repo root README) is displayed via `<PackageReadmeFile>`
+
+7. All existing tests continue to pass (182 tests as of Story 4.1)
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Update the existing README.md (AC: #1, #2, #3, #4)
+  - [ ] 1.1 Read current README at `src/libraries/Hexalith.Commons.UniqueIds/README.md`
+  - [ ] 1.2 Update the overview section to describe all THREE ID strategies (not just the original two)
+  - [ ] 1.3 Update the comparison table to include all three strategies with columns: Method, Format, Length, Sortable, Distributed-Safe, Use Case
+  - [ ] 1.4 Add a "ULID-Based IDs" section with `GenerateSortableUniqueStringId()` documentation and examples
+  - [ ] 1.5 Add a "Conversion Utilities" section covering `ExtractTimestamp`, `ToGuid`, `ToSortableUniqueId` with examples
+  - [ ] 1.6 Update "Decision Guide" to include the ULID strategy with clear recommendation: event sourcing/DDD → ULID
+  - [ ] 1.7 Update existing sections (Quick Start, Combined Usage, ID Generation Service) to include ULID examples
+  - [ ] 1.8 Ensure code examples are copy-paste ready and use correct API signatures
+
+- [ ] Task 2: Update .csproj for NuGet packaging (AC: #5, #6)
+  - [ ] 2.1 Add `<Description>` property with searchable terms (ULID, sortable, Base64URL, unique ID generation)
+  - [ ] 2.2 Add `<None Include="README.md" Pack="true" PackagePath="\" />` to include library-specific README
+  - [ ] 2.3 Override `<PackageReadmeFile>README.md</PackageReadmeFile>` if needed (may be inherited from Hexalith.Package.props)
+
+- [ ] Task 3: Build and test (AC: #7)
+  - [ ] 3.1 Run `dotnet build` — zero warnings
+  - [ ] 3.2 Run `dotnet test` — all 182 tests pass unchanged
+  - [ ] 3.3 Verify NuGet package contains the updated README: run `dotnet pack` and inspect the .nupkg
+
+- [ ] Task 4: Commit
+  - [ ] 4.1 Single commit: `docs(unique-ids): add ULID methods to README with comparison table`
+  - [ ] 4.2 CRITICAL: Tasks 1-3 must pass before commit
+
+## Dev Notes
+
+### Nature of This Story
+
+**This is a DOCUMENTATION + PACKAGING story.** Two files are modified:
+1. `src/libraries/Hexalith.Commons.UniqueIds/README.md` — content update
+2. `src/libraries/Hexalith.Commons.UniqueIds/Hexalith.Commons.UniqueIds.csproj` — NuGet metadata
+
+No new methods, no logic changes, no test changes. Tests must pass unchanged.
+
+### Current README State
+
+The README at `src/libraries/Hexalith.Commons.UniqueIds/README.md` already exists with good structure but only covers the **original two methods** (`GenerateDateTimeId` and `GenerateUniqueStringId`). It was written before Epics 2 and 3 added ULID capabilities. Key gaps:
+
+| Section | Current State | Required Update |
+|---------|--------------|-----------------|
+| Overview table | 2 methods only | Add `GenerateSortableUniqueStringId` row |
+| Quick Start | DateTime + Base64URL examples | Add ULID example |
+| Comparison table | 2 columns | Add ULID column, add "Distributed-Safe" and "Use Case" rows |
+| Decision Guide | 2 options | Add ULID recommendation for event sourcing |
+| ULID section | **MISSING** | New section with generation, timestamp extraction, conversion |
+| Conversion utilities | **MISSING** | New section for `ExtractTimestamp`, `ToGuid`, `ToSortableUniqueId` |
+| Combined Usage | Uses only old methods | Update to include ULID in examples |
+| Thread Safety | Covers old methods only | Add ULID concurrency example |
+
+### NuGet Packaging Configuration
+
+**Current state:**
+- `Hexalith.Builds/Hexalith.Package.props` sets `<PackageReadmeFile>README.md</PackageReadmeFile>` and packs `$(ProjectRoot)/README.md` (the REPO ROOT README, not the library-specific one)
+- The library's `.csproj` has NO `<Description>` override — it inherits the generic Hexalith description from `Hexalith.Package.props`
+- The library-specific `README.md` exists in the project directory but is NOT packed into the NuGet package
+
+**Required changes to `.csproj`:**
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Description>Unique identifier generation for .NET: ULID (sortable, distributed-safe), Base64URL GUID, and DateTime-based IDs with conversion utilities.</Description>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="ByteAether.Ulid" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+</Project>
+```
+
+**CRITICAL:** The `<None Include="README.md" Pack="true" PackagePath="\" />` overrides the repo-root README from `Hexalith.Package.props` because MSBuild uses the LAST matching `PackagePath` for `PackageReadmeFile`. The `<Description>` overrides the generic one. Do NOT modify `Hexalith.Package.props` — that's the shared submodule.
+
+### Comparison Table Design (AC #1, #4)
+
+The table must make the right choice **instantly obvious**:
+
+```markdown
+| | `GenerateDateTimeId()` | `GenerateUniqueStringId()` | `GenerateSortableUniqueStringId()` |
+|---|---|---|---|
+| **Format** | `yyyyMMddHHmmssfff` | Base64URL GUID | Crockford Base32 ULID |
+| **Length** | 17 chars | 22 chars | 26 chars |
+| **Sortable** | Yes (chronological) | No | Yes (chronological) |
+| **Distributed-Safe** | No (single machine) | Yes | Yes |
+| **Thread-Safe** | Yes (locked) | Yes (stateless) | Yes (monotonic) |
+| **Best For** | Log entries, file names | Legacy keys, session tokens | **Event sourcing, DDD aggregates** |
+```
+
+### Code Examples Required (AC #2)
+
+Every public method needs a working code example:
+
+1. **`GenerateDateTimeId()`** — already in README, keep/refresh
+2. **`GenerateUniqueStringId()`** — already in README, keep/refresh
+3. **`GenerateSortableUniqueStringId()`** — NEW: basic generation + sorting demo
+4. **`ExtractTimestamp(string ulid)`** — NEW: extract and use creation time
+5. **`ToGuid(string ulid)`** — NEW: convert for external system interop
+6. **`ToSortableUniqueId(Guid guid)`** — NEW: convert back from Guid
+
+Examples should show **real-world use cases** from the PRD user journeys:
+- Marco: Event sourcing with ULID IDs
+- Priya: Quick start discovering the right method
+- Sam: Migration from Base64URL to ULID
+- Li: Guid conversion for ERP interop
+
+### API Signatures (Verify Before Writing Examples)
+
+From current `UniqueIdHelper.cs` (confirmed):
+```csharp
+public static string GenerateDateTimeId()
+public static string GenerateUniqueStringId()
+public static string GenerateSortableUniqueStringId()
+public static DateTimeOffset ExtractTimestamp(string ulid)
+public static Guid ToGuid(string ulid)
+public static string ToSortableUniqueId(Guid value)  // param name is "value", not "guid"
+```
+
+### Architecture Compliance
+
+**ADR-004 (Identity not sort order):** The README must mention that `ToGuid()` preserves identity but NOT sort order. This caveat should appear in the conversion utilities section.
+
+**ADR-005 (No ByteAether in public API):** The README must NOT reference ByteAether as a dependency to consumers. Internally it uses ByteAether.Ulid, but the README should refer to "ULID specification" or "Crockford Base32 encoding."
+
+**FR11 (Comparison table):** Must show all three strategies side-by-side with enough information for 30-second decision-making.
+
+**FR12 (Code examples):** Must cover every public method with copy-paste ready code.
+
+### Anti-Patterns to Avoid
+
+1. **Do NOT reference ByteAether.Ulid in the README** — it's an internal dependency. Say "ULID specification" instead
+2. **Do NOT modify `UniqueIdHelper.cs`** — this story is documentation only
+3. **Do NOT modify test files** — this story adds no new functionality
+4. **Do NOT modify `Hexalith.Builds/Hexalith.Package.props`** — never modify the shared submodule without approval
+5. **Do NOT use incorrect parameter names in examples** — the Guid conversion method uses `value`, not `guid` (CA1720 compliance from Story 3.2)
+6. **Do NOT add encoding detail section for ULID** — replace the old "Encoding Details" Base64URL section with a more useful section. ULID encoding is handled by the library
+7. **Do NOT make the README too long** — NuGet renders README on the package page; keep it scannable. Focus on the comparison table and quick code examples
+8. **Do NOT change the NuGet badge URL** — keep the existing `[![NuGet]...]` badge
+
+### README Structure Recommendation
+
+Suggested section order for the updated README:
+1. Title + tagline (update to mention all three strategies)
+2. NuGet badge (keep existing)
+3. Overview with 3-strategy comparison table
+4. Installation
+5. Quick Start (all three methods in one code block)
+6. Method Reference (one subsection per method with example)
+7. Conversion Utilities (ExtractTimestamp, ToGuid, ToSortableUniqueId)
+8. Decision Guide (when to use each method)
+9. Thread Safety
+10. License + Links
+
+### Previous Story Intelligence
+
+**Story 4.1 (XML Documentation) established:**
+- All 6 public methods now have complete XML docs with `<summary>`, `<param>`, `<returns>`, `<remarks>`, and `<example>` tags
+- Class-level summary describes all three strategies
+- 182 tests passing baseline
+- Zero build warnings
+
+**Story 3.2 (Bidirectional ULID-Guid Conversion) established:**
+- `ToGuid(string ulid)` and `ToSortableUniqueId(Guid value)` are implemented and tested
+- Parameter name is `value` (not `guid`) for CA1720 compliance
+- Round-trip conversion: ULID → Guid → ULID is lossless
+- Non-ULID Guids (e.g., `Guid.NewGuid()`) produce valid ULID strings with meaningless timestamps
+
+**Story 3.1 (Extract Timestamp) established:**
+- `ExtractTimestamp(string ulid)` returns `DateTimeOffset` in UTC
+- Uses Crockford Base32 regex validation before parsing
+- Throws `ArgumentException` for null/empty, `FormatException` for invalid format
+
+**Story 2.1 (Sortable ID Generation) established:**
+- `GenerateSortableUniqueStringId()` returns 26-char Crockford Base32 string
+- Monotonic ordering within same millisecond
+- Thread-safe via `BaUlid.GenerationOptions` with monotonic increment
+
+### Git Intelligence
+
+Recent commits show the implementation sequence:
+- `feat(unique-ids): add bidirectional ULID-Guid conversion` (Story 3.2)
+- `feat(unique-ids): add ULID timestamp extraction` (Story 3.1)
+- `feat(unique-ids): add sortable ULID-based unique ID generation` (Story 2.1)
+
+All ULID functionality is now complete. This documentation story is the final deliverable.
+
+### Files to Modify (2 files, 0 new)
+
+| File | Action |
+|------|--------|
+| `src/libraries/Hexalith.Commons.UniqueIds/README.md` | Update content: add ULID methods, comparison table, code examples |
+| `src/libraries/Hexalith.Commons.UniqueIds/Hexalith.Commons.UniqueIds.csproj` | Add `<Description>` and `<None Include="README.md" Pack="true">` for NuGet packaging |
+
+### Build Verification
+
+- Run `dotnet build` — expect 0 warnings, 0 errors (documentation changes only)
+- Run `dotnet test` — expect 182/182 passed (no code changes)
+- Run `dotnet pack src/libraries/Hexalith.Commons.UniqueIds/Hexalith.Commons.UniqueIds.csproj` — verify .nupkg contains the updated README.md
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/epics.md#Epic 4 Story 4.2]
+- [Source: _bmad-output/planning-artifacts/prd.md#FR11, FR12]
+- [Source: _bmad-output/planning-artifacts/prd.md#User Journey 2 (Priya — Discovery Path)]
+- [Source: _bmad-output/planning-artifacts/architecture.md#ADR-004, ADR-005]
+- [Source: Hexalith.Builds/Hexalith.Package.props — PackageReadmeFile configuration]
+- [Source: src/libraries/Hexalith.Commons.UniqueIds/UniqueIdHelper.cs — current API surface]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+{{agent_model_name_version}}
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -56,11 +56,11 @@ development_status:
   # Epic 3: ID Conversion & Interoperability
   epic-3: in-progress
   3-1-extract-timestamp-from-ulid: done
-  3-2-bidirectional-ulid-guid-conversion: review
+  3-2-bidirectional-ulid-guid-conversion: done
   epic-3-retrospective: optional
 
   # Epic 4: API Documentation & Discoverability
-  epic-4: backlog
-  4-1-complete-xml-documentation-on-all-public-methods: backlog
+  epic-4: in-progress
+  4-1-complete-xml-documentation-on-all-public-methods: review
   4-2-create-readme-with-comparison-table-and-code-examples: backlog
   epic-4-retrospective: optional

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -56,7 +56,7 @@ development_status:
   # Epic 3: ID Conversion & Interoperability
   epic-3: in-progress
   3-1-extract-timestamp-from-ulid: done
-  3-2-bidirectional-ulid-guid-conversion: backlog
+  3-2-bidirectional-ulid-guid-conversion: in-progress
   epic-3-retrospective: optional
 
   # Epic 4: API Documentation & Discoverability

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -56,7 +56,7 @@ development_status:
   # Epic 3: ID Conversion & Interoperability
   epic-3: in-progress
   3-1-extract-timestamp-from-ulid: done
-  3-2-bidirectional-ulid-guid-conversion: in-progress
+  3-2-bidirectional-ulid-guid-conversion: review
   epic-3-retrospective: optional
 
   # Epic 4: API Documentation & Discoverability

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-03-14
-# last_updated: 2026-03-14
+# last_updated: 2026-03-14T15:45:56.5153060+01:00
 # project: Hexalith.Commons
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-03-14
-last_updated: 2026-03-14
+last_updated: 2026-03-14T15:54:29.8287176+01:00
 project: Hexalith.Commons
 project_key: NOKEY
 tracking_system: file-system
@@ -61,6 +61,6 @@ development_status:
 
   # Epic 4: API Documentation & Discoverability
   epic-4: in-progress
-  4-1-complete-xml-documentation-on-all-public-methods: review
-  4-2-create-readme-with-comparison-table-and-code-examples: backlog
+  4-1-complete-xml-documentation-on-all-public-methods: done
+  4-2-create-readme-with-comparison-table-and-code-examples: done
   epic-4-retrospective: optional

--- a/src/libraries/Hexalith.Commons.UniqueIds/Hexalith.Commons.UniqueIds.csproj
+++ b/src/libraries/Hexalith.Commons.UniqueIds/Hexalith.Commons.UniqueIds.csproj
@@ -1,10 +1,20 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>true</IsPackable>
+    <GeneratePackageOnBuild Condition="'$(IDEBuild)' == 'true'">false</GeneratePackageOnBuild>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <Description>Unique identifier generation for .NET: ULID (sortable, distributed-safe), Base64URL
+      GUID, and DateTime-based IDs with conversion utilities.</Description>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="ByteAether.Ulid" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="$(ProjectRoot)/README.md" Pack="false" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>

--- a/src/libraries/Hexalith.Commons.UniqueIds/README.md
+++ b/src/libraries/Hexalith.Commons.UniqueIds/README.md
@@ -1,6 +1,6 @@
 # Hexalith.Commons.UniqueIds
 
-> Lightweight unique identifier generation for .NET applications.
+> Three ID strategies for .NET — DateTime, Base64URL, and ULID — pick the right one in 30 seconds.
 
 [![NuGet](https://img.shields.io/nuget/v/Hexalith.Commons.UniqueIds.svg)](https://www.nuget.org/packages/Hexalith.Commons.UniqueIds)
 
@@ -8,12 +8,13 @@
 
 ## Overview
 
-**Hexalith.Commons.UniqueIds** provides two methods for generating unique identifiers, each optimized for different use cases:
+**Hexalith.Commons.UniqueIds** provides three unique identifier strategies via the static `UniqueIdHelper` class:
 
-| Method | Length | Format | Best For |
-|--------|--------|--------|----------|
-| `GenerateDateTimeId()` | 17 chars | `yyyyMMddHHmmssfff` | Sortable, human-readable IDs |
-| `GenerateUniqueStringId()` | 22 chars | Base64 URL-safe | Distributed systems, high throughput |
+| Method                             | Format                | Length   | Sortable            | Distributed-Safe    | Thread-Safe     | Best For                           |
+| ---------------------------------- | --------------------- | -------- | ------------------- | ------------------- | --------------- | ---------------------------------- |
+| `GenerateDateTimeId()`             | `yyyyMMddHHmmssfff`   | 17 chars | Yes (chronological) | No (single machine) | Yes (locked)    | Log entries, file names            |
+| `GenerateUniqueStringId()`         | Base64URL GUID        | 22 chars | No                  | Yes                 | Yes (stateless) | Legacy keys, session tokens        |
+| `GenerateSortableUniqueStringId()` | Crockford Base32 ULID | 26 chars | Yes (chronological) | Yes                 | Yes (monotonic) | **Event sourcing, DDD aggregates** |
 
 ---
 
@@ -30,293 +31,162 @@ dotnet add package Hexalith.Commons.UniqueIds
 ```csharp
 using Hexalith.Commons.UniqueIds;
 
-// DateTime-based ID (sortable, readable)
+// Sortable + distributed (event sourcing, DDD)
+string ulidId = UniqueIdHelper.GenerateSortableUniqueStringId();
+// "01HYX7QS3NP8M4KQJR5A7CVWKM" — 26-char ULID
+
+// Distributed (legacy keys, session tokens)
+string base64Id = UniqueIdHelper.GenerateUniqueStringId();
+// "gZOW2EgVrEq5SBJLegYcVA" — 22-char Base64URL
+
+// Human-readable (single machine, logs)
 string dateId = UniqueIdHelper.GenerateDateTimeId();
-// Example: "20240615143052789"
-
-// GUID-based ID (distributed-safe)
-string uniqueId = UniqueIdHelper.GenerateUniqueStringId();
-// Example: "gZOW2EgVrEq5SBJLegYcVA"
+// "20260314143052789" — 17-char timestamp
 ```
 
 ---
 
-## DateTime-Based IDs
+## Method Reference
 
-### GenerateDateTimeId()
+### GenerateSortableUniqueStringId()
 
-Generates a 17-character identifier based on the current UTC timestamp.
-
-```csharp
-public static string GenerateDateTimeId()
-```
-
-**Returns:** String in format `yyyyMMddHHmmssfff`
-
-**Example:**
-```csharp
-string id = UniqueIdHelper.GenerateDateTimeId();
-// "20240615143052789"
-//  ^^^^              Year (2024)
-//      ^^            Month (06 = June)
-//        ^^          Day (15)
-//          ^^        Hour (14 = 2 PM)
-//            ^^      Minute (30)
-//              ^^    Second (52)
-//                ^^^ Millisecond (789)
-```
-
-### Characteristics
-
-| Property | Value |
-|----------|-------|
-| Length | 17 characters |
-| Character set | 0-9 |
-| Timezone | UTC |
-| Sortable | Yes (chronological) |
-| Human readable | Yes |
-| Thread safe | Yes |
-| Max rate | 1 per millisecond |
-
-### Thread Safety
-
-The method is thread-safe and handles concurrent calls:
+Generates a 26-character ULID — sortable, distributed-safe, ideal for event sourcing.
 
 ```csharp
-// Thread-safe: automatic increment for same-millisecond calls
-var tasks = Enumerable.Range(0, 100)
-    .Select(_ => Task.Run(() => UniqueIdHelper.GenerateDateTimeId()));
+string id = UniqueIdHelper.GenerateSortableUniqueStringId();
+// "01HYX7QS3NP8M4KQJR5A7CVWKM"
 
-string[] ids = await Task.WhenAll(tasks);
-
-// All IDs are unique
-Debug.Assert(ids.Distinct().Count() == 100);
+// ULIDs sort chronologically as plain strings
+string[] ids = Enumerable.Range(0, 5)
+    .Select(_ => UniqueIdHelper.GenerateSortableUniqueStringId())
+    .ToArray();
+// ids are already in creation order — no OrderBy needed
 ```
-
-### Use Cases
-
-**Log correlation IDs:**
-```csharp
-public class LogEntry
-{
-    public string Id { get; } = UniqueIdHelper.GenerateDateTimeId();
-    public string Message { get; set; }
-    public DateTime Timestamp { get; set; }
-}
-
-// IDs sort naturally by creation time
-var logs = logEntries.OrderBy(l => l.Id);
-```
-
-**Sequential order numbers:**
-```csharp
-public class Order
-{
-    public string OrderNumber { get; } = UniqueIdHelper.GenerateDateTimeId();
-    // OrderNumber: "20240615143052789"
-}
-```
-
-**File naming with timestamp:**
-```csharp
-string backupFile = $"backup_{UniqueIdHelper.GenerateDateTimeId()}.zip";
-// "backup_20240615143052789.zip"
-```
-
-### Limitations
-
-- **Rate limit**: Maximum 1 unique ID per millisecond
-- **Single machine**: Not suitable for distributed ID generation
-- **Predictable**: Sequential nature may be undesirable for some use cases
-
----
-
-## GUID-Based IDs
 
 ### GenerateUniqueStringId()
 
-Generates a 22-character identifier derived from a GUID using URL-safe Base64 encoding.
+Generates a 22-character Base64URL string from a GUID. Distributed-safe but not sortable.
 
-```csharp
-public static string GenerateUniqueStringId()
-```
-
-**Returns:** 22-character URL-safe string
-
-**Example:**
 ```csharp
 string id = UniqueIdHelper.GenerateUniqueStringId();
 // "gZOW2EgVrEq5SBJLegYcVA"
-```
 
-### Characteristics
-
-| Property | Value |
-|----------|-------|
-| Length | 22 characters |
-| Character set | A-Z, a-z, 0-9, _, - |
-| Sortable | No |
-| Human readable | No |
-| Thread safe | Yes |
-| Uniqueness | Globally unique (GUID-based) |
-| URL safe | Yes |
-
-### Encoding Details
-
-The method:
-1. Generates a new GUID
-2. Converts to Base64
-3. Replaces `+` with `_` and `/` with `-`
-4. Truncates trailing `==` padding
-
-```csharp
-// Equivalent to:
-Guid guid = Guid.NewGuid();
-string base64 = Convert.ToBase64String(guid.ToByteArray());
-string urlSafe = base64.Replace('+', '_').Replace('/', '-').TrimEnd('=');
-// Result: 22 characters
-```
-
-### Use Cases
-
-**Primary keys:**
-```csharp
-public class Entity
-{
-    public string Id { get; } = UniqueIdHelper.GenerateUniqueStringId();
-}
-
-// Short, URL-safe IDs for REST APIs
+// URL-safe — use directly in REST routes
 // GET /api/orders/gZOW2EgVrEq5SBJLegYcVA
 ```
 
-**Distributed systems:**
-```csharp
-// Safe to generate across multiple servers
-public class DistributedEvent
-{
-    public string EventId { get; } = UniqueIdHelper.GenerateUniqueStringId();
-    public string Payload { get; set; }
-}
-```
+### GenerateDateTimeId()
 
-**Session tokens:**
-```csharp
-string sessionId = UniqueIdHelper.GenerateUniqueStringId();
-Response.Cookies.Append("session", sessionId);
-```
+Generates a 17-character UTC timestamp ID. Human-readable and sortable, but single-machine only.
 
-**Correlation IDs for distributed tracing:**
 ```csharp
-public class RequestContext
-{
-    public string CorrelationId { get; } = UniqueIdHelper.GenerateUniqueStringId();
-}
+string id = UniqueIdHelper.GenerateDateTimeId();
+// "20260314143052789"
 
-// Pass through HTTP headers
-httpClient.DefaultRequestHeaders.Add("X-Correlation-Id", context.CorrelationId);
+// Format breakdown: yyyyMMddHHmmssfff
+// Thread-safe: same-millisecond calls auto-increment
 ```
 
 ---
 
-## Comparison
+## Conversion Utilities
 
-| Feature | GenerateDateTimeId | GenerateUniqueStringId |
-|---------|-------------------|----------------------|
-| **Length** | 17 chars | 22 chars |
-| **Characters** | 0-9 only | Alphanumeric + _ - |
-| **Sortable** | Yes | No |
-| **Human readable** | Yes | No |
-| **Distributed safe** | No | Yes |
-| **Rate limit** | 1/ms | Unlimited |
-| **Predictable** | Yes | No |
-| **URL safe** | Yes | Yes |
+### ExtractTimestamp(string ulid)
 
-### Decision Guide
+Need to know when an entity was created? Extract the embedded UTC timestamp from any ULID.
 
-Use `GenerateDateTimeId()` when:
-- IDs need to be sortable by creation time
-- Human readability is important
-- Single-server deployment
-- Low throughput (< 1000/second)
+```csharp
+string ulid = UniqueIdHelper.GenerateSortableUniqueStringId();
+DateTimeOffset created = UniqueIdHelper.ExtractTimestamp(ulid);
+// Returns the exact UTC time the ULID was generated
+```
 
-Use `GenerateUniqueStringId()` when:
-- Distributed system with multiple servers
-- High throughput requirements
-- Unpredictable IDs preferred
-- Standard GUID uniqueness guarantees needed
+### ToGuid(string ulid)
+
+Your ERP only accepts GUIDs? Convert your internal ULID while preserving the 128-bit identity.
+
+```csharp
+string ulid = UniqueIdHelper.GenerateSortableUniqueStringId();
+Guid guid = UniqueIdHelper.ToGuid(ulid);
+// Use guid for external systems that require System.Guid
+```
+
+> **Note:** `ToGuid` preserves identity but NOT lexicographic sort order. Two ULIDs that sort correctly as strings may not sort the same way as Guids due to byte-order differences.
+
+### ToSortableUniqueId(Guid value)
+
+Converting back from a Guid to a ULID string? Round-trip is lossless for Guids originally derived from ULIDs.
+
+```csharp
+// Round-trip: ULID → Guid → ULID
+string original = UniqueIdHelper.GenerateSortableUniqueStringId();
+Guid guid = UniqueIdHelper.ToGuid(original);
+string restored = UniqueIdHelper.ToSortableUniqueId(guid);
+// restored == original (case-insensitive)
+```
+
+> **Note:** Converting a non-ULID Guid (e.g., `Guid.NewGuid()`) produces a valid ULID string, but its embedded timestamp is meaningless.
 
 ---
 
-## Examples
+## Decision Guide
 
-### Combined Usage
+| Use Case                              | Recommended Method                                              |
+| ------------------------------------- | --------------------------------------------------------------- |
+| **Event sourcing / DDD aggregates**   | `GenerateSortableUniqueStringId()` — sortable + distributed     |
+| **Distributed keys / session tokens** | `GenerateUniqueStringId()` — compact + GUID-backed              |
+| **Log entries / file names**          | `GenerateDateTimeId()` — human-readable timestamps              |
+| **Migrating Base64URL to ULID**       | Generate ULID for new records; keep old Base64URL IDs unchanged |
+| **Interop with Guid-only systems**    | `ToGuid()` / `ToSortableUniqueId()` — lossless round-trip       |
+
+---
+
+## Combined Usage
 
 ```csharp
 public class AuditLog
 {
-    // Sortable, timestamp-based ID for ordering
-    public string LogId { get; } = UniqueIdHelper.GenerateDateTimeId();
+    // ULID: sortable, distributed-safe event ID
+    public string EventId { get; } = UniqueIdHelper.GenerateSortableUniqueStringId();
 
-    // Globally unique correlation for distributed tracing
+    // Base64URL: globally unique correlation for tracing
     public string CorrelationId { get; set; }
 
     public string Action { get; set; }
     public string UserId { get; set; }
 }
 
-// Usage
 var log = new AuditLog
 {
     CorrelationId = UniqueIdHelper.GenerateUniqueStringId(),
-    Action = "UserLogin",
-    UserId = "user123"
+    Action = "OrderPlaced",
+    UserId = "user-42"
 };
-```
-
-### ID Generation Service
-
-```csharp
-public interface IIdGenerator
-{
-    string NewId();
-    string NewSortableId();
-}
-
-public class HexalithIdGenerator : IIdGenerator
-{
-    public string NewId() => UniqueIdHelper.GenerateUniqueStringId();
-    public string NewSortableId() => UniqueIdHelper.GenerateDateTimeId();
-}
-
-// Register in DI
-services.AddSingleton<IIdGenerator, HexalithIdGenerator>();
 ```
 
 ---
 
 ## Thread Safety
 
-Both methods are fully thread-safe:
+All three methods are fully thread-safe:
 
 ```csharp
-// Concurrent generation test
 var ids = new ConcurrentBag<string>();
 
-Parallel.For(0, 10000, _ =>
+Parallel.For(0, 10_000, _ =>
 {
-    ids.Add(UniqueIdHelper.GenerateUniqueStringId());
+    ids.Add(UniqueIdHelper.GenerateSortableUniqueStringId());
 });
 
-// All 10,000 IDs are unique
-Debug.Assert(ids.Distinct().Count() == 10000);
+// All 10,000 IDs are unique and in monotonic order within each millisecond
+Debug.Assert(ids.Distinct().Count() == 10_000);
 ```
 
 ---
 
 ## License
 
-MIT License - See [LICENSE](../../../LICENSE) for details.
+MIT License — See [LICENSE](../../../LICENSE) for details.
 
 ---
 

--- a/src/libraries/Hexalith.Commons.UniqueIds/UniqueIdHelper.cs
+++ b/src/libraries/Hexalith.Commons.UniqueIds/UniqueIdHelper.cs
@@ -13,7 +13,9 @@ using System.Threading;
 using BaUlid = ByteAether.Ulid.Ulid;
 
 /// <summary>
-/// Provides helper methods for generating unique IDs.
+/// Provides static methods for generating unique identifiers in three strategies:
+/// DateTime-based (human-readable, single-machine), Base64URL GUID (distributed-safe, unsorted),
+/// and ULID (sortable, distributed-safe). Also provides conversion utilities between ULID strings and Guids.
 /// </summary>
 public static partial class UniqueIdHelper
 {
@@ -36,6 +38,16 @@ public static partial class UniqueIdHelper
     /// <returns>A <see cref="DateTimeOffset"/> representing the ULID's creation time in UTC.</returns>
     /// <exception cref="ArgumentException">Thrown when <paramref name="ulid"/> is null, empty, or whitespace.</exception>
     /// <exception cref="FormatException">Thrown when <paramref name="ulid"/> is not a valid ULID string.</exception>
+    /// <remarks>
+    /// The ULID timestamp encodes Unix epoch milliseconds in UTC. The returned
+    /// <see cref="DateTimeOffset"/> always has zero UTC offset.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// DateTimeOffset timestamp = UniqueIdHelper.ExtractTimestamp("01HYX7QS3NP8M4KQJR5A7CVWKM");
+    /// // Returns the UTC time at which the ULID was generated.
+    /// </code>
+    /// </example>
     public static DateTimeOffset ExtractTimestamp(string ulid)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ulid);
@@ -44,7 +56,7 @@ public static partial class UniqueIdHelper
             throw new FormatException($"The value '{ulid}' is not a valid ULID string.");
         }
 
-        return BaUlid.Parse(ulid, CultureInfo.InvariantCulture).Time;
+        return BaUlid.Parse(ulid.ToUpperInvariant(), CultureInfo.InvariantCulture).Time;
     }
 
     /// <summary>
@@ -52,6 +64,17 @@ public static partial class UniqueIdHelper
     /// It ensures uniqueness by incrementing the time if multiple calls occur within the same millisecond.
     /// </summary>
     /// <returns>A unique 17-character ID string derived from the current date/time.</returns>
+    /// <remarks>
+    /// This method is thread-safe via an exclusive lock. The format is "yyyyMMddHHmmssfff",
+    /// which provides human-readable, monotonically increasing IDs on a single machine.
+    /// Not suitable for distributed systems — use <see cref="GenerateSortableUniqueStringId"/> instead.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// string id = UniqueIdHelper.GenerateDateTimeId();
+    /// // Returns: "20260314120530123" (17-character timestamp string)
+    /// </code>
+    /// </example>
     public static string GenerateDateTimeId()
     {
         using (_dateTimeLock.EnterScope())
@@ -83,6 +106,17 @@ public static partial class UniqueIdHelper
     /// event sourcing, aggregate identifiers, and any use case requiring natural ordering.
     /// </summary>
     /// <returns>A 26-character Crockford Base32 encoded ULID string.</returns>
+    /// <remarks>
+    /// This method is thread-safe via monotonic increment options that guarantee
+    /// within-millisecond ordering. ULIDs are suitable for event sourcing,
+    /// aggregate identifiers, and any distributed system requiring natural time ordering.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// string id = UniqueIdHelper.GenerateSortableUniqueStringId();
+    /// // Returns: "01HYX7QS3NP8M4KQJR5A7CVWKM" (26-char Crockford Base32)
+    /// </code>
+    /// </example>
     public static string GenerateSortableUniqueStringId()
         => BaUlid.New(_ulidOptions).ToString();
 
@@ -90,6 +124,17 @@ public static partial class UniqueIdHelper
     /// Generates a unique 22-character ID string derived from a GUID encoded in Base64 URL-safe format.
     /// </summary>
     /// <returns>A 22-character unique ID string.</returns>
+    /// <remarks>
+    /// This method is stateless and requires no locking. The character set is
+    /// A-Za-z0-9, underscore, and hyphen (Base64 URL-safe). Use this method when
+    /// a unique key is needed but sort order is not important.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// string id = UniqueIdHelper.GenerateUniqueStringId();
+    /// // Returns: "a1B2c3D4e5F6g7H8i9J0kL" (22-char Base64 URL-safe)
+    /// </code>
+    /// </example>
     public static string GenerateUniqueStringId() =>
         Convert
             .ToBase64String(Guid.NewGuid().ToByteArray())[..22]
@@ -108,6 +153,12 @@ public static partial class UniqueIdHelper
     /// </remarks>
     /// <exception cref="ArgumentException">Thrown when <paramref name="ulid"/> is null, empty, or whitespace.</exception>
     /// <exception cref="FormatException">Thrown when <paramref name="ulid"/> is not a valid ULID string.</exception>
+    /// <example>
+    /// <code>
+    /// Guid guid = UniqueIdHelper.ToGuid("01HYX7QS3NP8M4KQJR5A7CVWKM");
+    /// // Converts the ULID to a Guid preserving the 128-bit identity.
+    /// </code>
+    /// </example>
     public static Guid ToGuid(string ulid)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ulid);
@@ -116,7 +167,14 @@ public static partial class UniqueIdHelper
             throw new FormatException($"The value '{ulid}' is not a valid ULID string.");
         }
 
-        return BaUlid.Parse(ulid, CultureInfo.InvariantCulture).ToGuid();
+        try
+        {
+            return BaUlid.Parse(ulid.ToUpperInvariant(), CultureInfo.InvariantCulture).ToGuid();
+        }
+        catch (Exception ex)
+        {
+            throw new FormatException($"The value '{ulid}' is not a valid ULID string.", ex);
+        }
     }
 
     /// <summary>
@@ -128,9 +186,15 @@ public static partial class UniqueIdHelper
     /// When called with a Guid not originally derived from a ULID (e.g., <see cref="Guid.NewGuid()"/>),
     /// the result is a valid ULID string but its embedded timestamp is meaningless.
     /// </remarks>
+    /// <example>
+    /// <code>
+    /// string ulid = UniqueIdHelper.ToSortableUniqueId(myGuid);
+    /// // Returns a 26-character ULID string from the Guid's 128 bits.
+    /// </code>
+    /// </example>
     public static string ToSortableUniqueId(Guid value)
         => BaUlid.New(value).ToString();
 
-    [GeneratedRegex("^[0-9A-HJKMNP-TV-Z]{26}$")]
+    [GeneratedRegex("^[0-9A-HJKMNP-TV-Z]{26}$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex CrockfordBase32Pattern();
 }

--- a/src/libraries/Hexalith.Commons.UniqueIds/UniqueIdHelper.cs
+++ b/src/libraries/Hexalith.Commons.UniqueIds/UniqueIdHelper.cs
@@ -96,6 +96,41 @@ public static partial class UniqueIdHelper
             .Replace("/", "_", StringComparison.InvariantCulture)
             .Replace("+", "-", StringComparison.InvariantCulture);
 
+    /// <summary>
+    /// Converts a ULID string to a <see cref="Guid"/>.
+    /// </summary>
+    /// <param name="ulid">A 26-character Crockford Base32 ULID string.</param>
+    /// <returns>A <see cref="Guid"/> preserving the ULID's 128-bit identity.</returns>
+    /// <remarks>
+    /// The resulting Guid preserves identity but NOT lexicographic sort order.
+    /// Two ULIDs that sort correctly as strings may not sort the same way as Guids
+    /// due to Guid byte-order differences.
+    /// </remarks>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="ulid"/> is null, empty, or whitespace.</exception>
+    /// <exception cref="FormatException">Thrown when <paramref name="ulid"/> is not a valid ULID string.</exception>
+    public static Guid ToGuid(string ulid)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(ulid);
+        if (!CrockfordBase32Pattern().IsMatch(ulid))
+        {
+            throw new FormatException($"The value '{ulid}' is not a valid ULID string.");
+        }
+
+        return BaUlid.Parse(ulid, CultureInfo.InvariantCulture).ToGuid();
+    }
+
+    /// <summary>
+    /// Converts a <see cref="Guid"/> to a 26-character ULID string.
+    /// </summary>
+    /// <param name="value">The Guid to convert.</param>
+    /// <returns>A 26-character Crockford Base32 ULID string.</returns>
+    /// <remarks>
+    /// When called with a Guid not originally derived from a ULID (e.g., <see cref="Guid.NewGuid()"/>),
+    /// the result is a valid ULID string but its embedded timestamp is meaningless.
+    /// </remarks>
+    public static string ToSortableUniqueId(Guid value)
+        => BaUlid.New(value).ToString();
+
     [GeneratedRegex("^[0-9A-HJKMNP-TV-Z]{26}$")]
     private static partial Regex CrockfordBase32Pattern();
 }

--- a/test/Hexalith.Commons.Tests/UniqueIds/UniqueHelperTest.cs
+++ b/test/Hexalith.Commons.Tests/UniqueIds/UniqueHelperTest.cs
@@ -291,6 +291,105 @@ public partial class UniqueHelperTest
         ids.ShouldBe(sorted);
     }
 
+    /// <summary>
+    /// Tests that converting a valid ULID to Guid and back returns the original ULID string (lossless round-trip).
+    /// </summary>
+    [Fact]
+    public void ConvertSortableUniqueIdToGuidAndBackShouldReturnOriginalValue()
+    {
+        string original = UniqueIdHelper.GenerateSortableUniqueStringId();
+        var guid = UniqueIdHelper.ToGuid(original);
+        string roundTripped = UniqueIdHelper.ToSortableUniqueId(guid);
+        roundTripped.ShouldBe(original);
+    }
+
+    /// <summary>
+    /// Tests that 100 generated ULIDs all survive Guid round-trip conversion without data loss.
+    /// </summary>
+    [Fact]
+    public void ConvertAHundredSortableUniqueIdsToGuidAndBackShouldAllReturnOriginalValues()
+    {
+        for (int i = 0; i < 100; i++)
+        {
+            string original = UniqueIdHelper.GenerateSortableUniqueStringId();
+            var guid = UniqueIdHelper.ToGuid(original);
+            string roundTripped = UniqueIdHelper.ToSortableUniqueId(guid);
+            roundTripped.ShouldBe(original);
+        }
+    }
+
+    /// <summary>
+    /// Tests that converting a valid ULID string to Guid returns a non-empty Guid.
+    /// </summary>
+    [Fact]
+    public void ToGuidFromValidUlidReturnsNonEmptyGuid()
+    {
+        string ulid = UniqueIdHelper.GenerateSortableUniqueStringId();
+        var guid = UniqueIdHelper.ToGuid(ulid);
+        guid.ShouldNotBe(Guid.Empty);
+    }
+
+    /// <summary>
+    /// Tests that passing null, empty, or whitespace to ToGuid throws ArgumentException.
+    /// </summary>
+    /// <param name="ulid">The invalid input to test.</param>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ToGuidFromNullOrWhiteSpaceThrowsArgumentException(string? ulid)
+        => Should.Throw<ArgumentException>(() => UniqueIdHelper.ToGuid(ulid!));
+
+    /// <summary>
+    /// Tests that passing an invalid ULID format to ToGuid throws FormatException.
+    /// </summary>
+    /// <param name="ulid">The invalid ULID string to test.</param>
+    [Theory]
+    [InlineData("short")]
+    [InlineData("THIS_IS_NOT_A_VALID_ULID!!")]
+    [InlineData("01ARZ3NDEKTSV4RRFFQ69G5FA!")]
+    public void ToGuidFromInvalidFormatThrowsFormatException(string ulid)
+        => Should.Throw<FormatException>(() => UniqueIdHelper.ToGuid(ulid));
+
+    /// <summary>
+    /// Tests that converting a Guid to ULID string returns a valid 26-character Crockford Base32 string.
+    /// </summary>
+    [Fact]
+    public void ToSortableUniqueIdFromGuidReturns26CharCrockfordBase32String()
+    {
+        var guid = UniqueIdHelper.ToGuid(UniqueIdHelper.GenerateSortableUniqueStringId());
+        string result = UniqueIdHelper.ToSortableUniqueId(guid);
+        result.Length.ShouldBe(26);
+        CrockfordBase32Pattern().IsMatch(result).ShouldBeTrue();
+    }
+
+    /// <summary>
+    /// Tests that a non-ULID Guid (e.g., Guid.NewGuid()) produces a valid ULID string
+    /// with an extractable timestamp (does not throw).
+    /// </summary>
+    [Fact]
+    public void ToSortableUniqueIdFromRandomGuidProducesValidUlidWithExtractableTimestamp()
+    {
+        var randomGuid = Guid.NewGuid();
+        string ulid = UniqueIdHelper.ToSortableUniqueId(randomGuid);
+        ulid.Length.ShouldBe(26);
+        CrockfordBase32Pattern().IsMatch(ulid).ShouldBeTrue();
+
+        // Should not throw — edge case per architecture
+        _ = UniqueIdHelper.ExtractTimestamp(ulid);
+    }
+
+    /// <summary>
+    /// Tests that converting Guid.Empty produces a valid 26-character ULID string.
+    /// </summary>
+    [Fact]
+    public void ToSortableUniqueIdFromEmptyGuidReturnsAllZerosUlid()
+    {
+        string ulid = UniqueIdHelper.ToSortableUniqueId(Guid.Empty);
+        ulid.Length.ShouldBe(26);
+        CrockfordBase32Pattern().IsMatch(ulid).ShouldBeTrue();
+    }
+
     [GeneratedRegex("^[A-Za-z0-9_-]{22}$")]
     private static partial Regex Base64UrlPattern();
 

--- a/test/Hexalith.Commons.Tests/UniqueIds/UniqueHelperTest.cs
+++ b/test/Hexalith.Commons.Tests/UniqueIds/UniqueHelperTest.cs
@@ -330,6 +330,20 @@ public partial class UniqueHelperTest
     }
 
     /// <summary>
+    /// Tests that a lowercase ULID string is accepted and preserves identity through Guid round-trip conversion.
+    /// </summary>
+    [Fact]
+    public void ToGuidFromLowercaseUlidRoundTripsToOriginalCanonicalValue()
+    {
+        string original = UniqueIdHelper.GenerateSortableUniqueStringId();
+        string lowercase = new([.. original.Select(char.ToLowerInvariant)]);
+
+        var guid = UniqueIdHelper.ToGuid(lowercase);
+
+        UniqueIdHelper.ToSortableUniqueId(guid).ShouldBe(original);
+    }
+
+    /// <summary>
     /// Tests that passing null, empty, or whitespace to ToGuid throws ArgumentException.
     /// </summary>
     /// <param name="ulid">The invalid input to test.</param>
@@ -349,7 +363,12 @@ public partial class UniqueHelperTest
     [InlineData("THIS_IS_NOT_A_VALID_ULID!!")]
     [InlineData("01ARZ3NDEKTSV4RRFFQ69G5FA!")]
     public void ToGuidFromInvalidFormatThrowsFormatException(string ulid)
-        => Should.Throw<FormatException>(() => UniqueIdHelper.ToGuid(ulid));
+    {
+        FormatException exception = Should.Throw<FormatException>(() => UniqueIdHelper.ToGuid(ulid));
+
+        exception.Message.ShouldContain("not a valid ULID string");
+        exception.Message.ShouldContain(ulid);
+    }
 
     /// <summary>
     /// Tests that converting a Guid to ULID string returns a valid 26-character Crockford Base32 string.
@@ -386,6 +405,7 @@ public partial class UniqueHelperTest
     public void ToSortableUniqueIdFromEmptyGuidReturnsAllZerosUlid()
     {
         string ulid = UniqueIdHelper.ToSortableUniqueId(Guid.Empty);
+        ulid.ShouldBe("00000000000000000000000000");
         ulid.Length.ShouldBe(26);
         CrockfordBase32Pattern().IsMatch(ulid).ShouldBeTrue();
     }


### PR DESCRIPTION
## Summary

- Add bidirectional ULID-Guid conversion methods (`ToGuid` and `ToSortableUniqueId`) to `UniqueIdHelper`
- Complete XML documentation on all public methods (Story 4-1)
- Create README with three-strategy comparison table, ULID code examples, conversion utilities, and decision guide (Story 4-2)
- Configure .csproj to pack library-specific README into NuGet package
- Update sprint status: Epic 3 and Epic 4 stories marked as done

## Test plan

- [x] All 183 unit tests pass
- [x] `dotnet build` with zero warnings
- [x] NuGet package includes library-specific README
- [x] XML documentation file generated on build

🤖 Generated with [Claude Code](https://claude.com/claude-code)