### PR TITLE
build: add standalone governance solution

### DIFF
--- a/Hexalith.Commons.Standalone.slnx
+++ b/Hexalith.Commons.Standalone.slnx
@@ -1,0 +1,31 @@
+<Solution>
+  <Configurations>
+    <Platform Name="Any CPU" />
+    <Platform Name="x64" />
+    <Platform Name="x86" />
+  </Configurations>
+  <Folder Name="/src/libraries/">
+    <Project Path="src/libraries/Hexalith.Commons/Hexalith.Commons.csproj" />
+    <Project Path="src/libraries/Hexalith.Commons.Aspire/Hexalith.Commons.Aspire.csproj" />
+    <Project Path="src/libraries/Hexalith.Commons.Configurations/Hexalith.Commons.Configurations.csproj" />
+    <Project Path="src/libraries/Hexalith.Commons.Diagnostics/Hexalith.Commons.Diagnostics.csproj" />
+    <Project Path="src/libraries/Hexalith.Commons.Http/Hexalith.Commons.Http.csproj" />
+    <Project Path="src/libraries/Hexalith.Commons.Metadatas/Hexalith.Commons.Metadatas.csproj" />
+    <Project Path="src/libraries/Hexalith.Commons.Publication/Hexalith.Commons.Publication.csproj" />
+    <Project Path="src/libraries/Hexalith.Commons.Serialization/Hexalith.Commons.Serialization.csproj" />
+    <Project Path="src/libraries/Hexalith.Commons.ServiceDefaults/Hexalith.Commons.ServiceDefaults.csproj" />
+    <Project Path="src/libraries/Hexalith.Commons.StringEncoders/Hexalith.Commons.StringEncoders.csproj" />
+    <Project Path="src/libraries/Hexalith.Commons.TenantAccess/Hexalith.Commons.TenantAccess.csproj" />
+    <Project Path="src/libraries/Hexalith.Commons.UniqueIds/Hexalith.Commons.UniqueIds.csproj" />
+  </Folder>
+  <Folder Name="/test/">
+    <Project Path="test/Hexalith.Commons.Aspire.Tests/Hexalith.Commons.Aspire.Tests.csproj" />
+    <Project Path="test/Hexalith.Commons.Diagnostics.Tests/Hexalith.Commons.Diagnostics.Tests.csproj" />
+    <Project Path="test/Hexalith.Commons.Tests/Hexalith.Commons.Tests.csproj" />
+    <Project Path="test/Hexalith.Commons.Http.Tests/Hexalith.Commons.Http.Tests.csproj" />
+    <Project Path="test/Hexalith.Commons.Publication.Tests/Hexalith.Commons.Publication.Tests.csproj" />
+    <Project Path="test/Hexalith.Commons.Serialization.Tests/Hexalith.Commons.Serialization.Tests.csproj" />
+    <Project Path="test/Hexalith.Commons.ServiceDefaults.Tests/Hexalith.Commons.ServiceDefaults.Tests.csproj" />
+    <Project Path="test/Hexalith.Commons.TenantAccess.Tests/Hexalith.Commons.TenantAccess.Tests.csproj" />
+  </Folder>
+</Solution>

--- a/README.md
+++ b/README.md
@@ -506,9 +506,16 @@ cd Hexalith.Commons
 # Build
 dotnet build
 
+# Build the complete owned-project package-mode surface used by dependency governance
+dotnet build Hexalith.Commons.Standalone.slnx -c Release -p:UseNuGetDeps=true
+
 # Run tests
 dotnet test
 ```
+
+`Hexalith.Commons.slnx` remains the canonical development solution. The
+`Hexalith.Commons.Standalone.slnx` solution is a governance-only inventory of all
+20 owned projects and deliberately excludes projects and files under `references/`.
 
 ---
 

--- a/test/Hexalith.Commons.Tests/SolutionInventoryTest.cs
+++ b/test/Hexalith.Commons.Tests/SolutionInventoryTest.cs
@@ -14,29 +14,7 @@ using Shouldly;
 /// </summary>
 public class SolutionInventoryTest
 {
-    private static readonly string[] ExpectedProjects =
-    [
-        "src/libraries/Hexalith.Commons.Aspire/Hexalith.Commons.Aspire.csproj",
-        "src/libraries/Hexalith.Commons.Configurations/Hexalith.Commons.Configurations.csproj",
-        "src/libraries/Hexalith.Commons.Diagnostics/Hexalith.Commons.Diagnostics.csproj",
-        "src/libraries/Hexalith.Commons.Http/Hexalith.Commons.Http.csproj",
-        "src/libraries/Hexalith.Commons.Metadatas/Hexalith.Commons.Metadatas.csproj",
-        "src/libraries/Hexalith.Commons.Publication/Hexalith.Commons.Publication.csproj",
-        "src/libraries/Hexalith.Commons.Serialization/Hexalith.Commons.Serialization.csproj",
-        "src/libraries/Hexalith.Commons.ServiceDefaults/Hexalith.Commons.ServiceDefaults.csproj",
-        "src/libraries/Hexalith.Commons.StringEncoders/Hexalith.Commons.StringEncoders.csproj",
-        "src/libraries/Hexalith.Commons.TenantAccess/Hexalith.Commons.TenantAccess.csproj",
-        "src/libraries/Hexalith.Commons.UniqueIds/Hexalith.Commons.UniqueIds.csproj",
-        "src/libraries/Hexalith.Commons/Hexalith.Commons.csproj",
-        "test/Hexalith.Commons.Aspire.Tests/Hexalith.Commons.Aspire.Tests.csproj",
-        "test/Hexalith.Commons.Diagnostics.Tests/Hexalith.Commons.Diagnostics.Tests.csproj",
-        "test/Hexalith.Commons.Http.Tests/Hexalith.Commons.Http.Tests.csproj",
-        "test/Hexalith.Commons.Publication.Tests/Hexalith.Commons.Publication.Tests.csproj",
-        "test/Hexalith.Commons.Serialization.Tests/Hexalith.Commons.Serialization.Tests.csproj",
-        "test/Hexalith.Commons.ServiceDefaults.Tests/Hexalith.Commons.ServiceDefaults.Tests.csproj",
-        "test/Hexalith.Commons.TenantAccess.Tests/Hexalith.Commons.TenantAccess.Tests.csproj",
-        "test/Hexalith.Commons.Tests/Hexalith.Commons.Tests.csproj",
-    ];
+    private static readonly string[] OwnedProjectRoots = ["src", "test"];
 
     /// <summary>
     /// Verifies that the standalone solution contains every owned project and no dependency paths.
@@ -53,12 +31,26 @@ public class SolutionInventoryTest
             .Order(StringComparer.Ordinal),
         ];
 
-        projectPaths.ShouldBe(ExpectedProjects.Order(StringComparer.Ordinal));
+        projectPaths.ShouldBe(EnumerateOwnedProjectFiles(repositoryRoot));
         solution.Descendants()
             .Where(element => element.Name.LocalName is "Project" or "File")
             .Select(element => NormalizePath((string?)element.Attribute("Path")))
             .ShouldAllBe(path => !path.StartsWith("references/", StringComparison.Ordinal));
     }
+
+    private static string[] EnumerateOwnedProjectFiles(string repositoryRoot) =>
+        [
+            .. OwnedProjectRoots
+                .SelectMany(root => Directory.EnumerateFiles(
+                    Path.Combine(repositoryRoot, root),
+                    "*.csproj",
+                    SearchOption.AllDirectories))
+                .Where(path => !NormalizePath(Path.GetRelativePath(repositoryRoot, path))
+                    .Split('/')
+                    .Any(segment => segment is "bin" or "obj"))
+                .Select(path => NormalizePath(Path.GetRelativePath(repositoryRoot, path)))
+                .Order(StringComparer.Ordinal),
+        ];
 
     private static string FindRepositoryRoot()
     {

--- a/test/Hexalith.Commons.Tests/SolutionInventoryTest.cs
+++ b/test/Hexalith.Commons.Tests/SolutionInventoryTest.cs
@@ -1,0 +1,77 @@
+// <copyright file="SolutionInventoryTest.cs" company="ITANEO">
+// Copyright (c) ITANEO (https://www.itaneo.com). All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace Hexalith.Commons.Tests;
+
+using System.Xml.Linq;
+
+using Shouldly;
+
+/// <summary>
+/// Verifies the governance-only standalone solution inventory.
+/// </summary>
+public class SolutionInventoryTest
+{
+    private static readonly string[] ExpectedProjects =
+    [
+        "src/libraries/Hexalith.Commons.Aspire/Hexalith.Commons.Aspire.csproj",
+        "src/libraries/Hexalith.Commons.Configurations/Hexalith.Commons.Configurations.csproj",
+        "src/libraries/Hexalith.Commons.Diagnostics/Hexalith.Commons.Diagnostics.csproj",
+        "src/libraries/Hexalith.Commons.Http/Hexalith.Commons.Http.csproj",
+        "src/libraries/Hexalith.Commons.Metadatas/Hexalith.Commons.Metadatas.csproj",
+        "src/libraries/Hexalith.Commons.Publication/Hexalith.Commons.Publication.csproj",
+        "src/libraries/Hexalith.Commons.Serialization/Hexalith.Commons.Serialization.csproj",
+        "src/libraries/Hexalith.Commons.ServiceDefaults/Hexalith.Commons.ServiceDefaults.csproj",
+        "src/libraries/Hexalith.Commons.StringEncoders/Hexalith.Commons.StringEncoders.csproj",
+        "src/libraries/Hexalith.Commons.TenantAccess/Hexalith.Commons.TenantAccess.csproj",
+        "src/libraries/Hexalith.Commons.UniqueIds/Hexalith.Commons.UniqueIds.csproj",
+        "src/libraries/Hexalith.Commons/Hexalith.Commons.csproj",
+        "test/Hexalith.Commons.Aspire.Tests/Hexalith.Commons.Aspire.Tests.csproj",
+        "test/Hexalith.Commons.Diagnostics.Tests/Hexalith.Commons.Diagnostics.Tests.csproj",
+        "test/Hexalith.Commons.Http.Tests/Hexalith.Commons.Http.Tests.csproj",
+        "test/Hexalith.Commons.Publication.Tests/Hexalith.Commons.Publication.Tests.csproj",
+        "test/Hexalith.Commons.Serialization.Tests/Hexalith.Commons.Serialization.Tests.csproj",
+        "test/Hexalith.Commons.ServiceDefaults.Tests/Hexalith.Commons.ServiceDefaults.Tests.csproj",
+        "test/Hexalith.Commons.TenantAccess.Tests/Hexalith.Commons.TenantAccess.Tests.csproj",
+        "test/Hexalith.Commons.Tests/Hexalith.Commons.Tests.csproj",
+    ];
+
+    /// <summary>
+    /// Verifies that the standalone solution contains every owned project and no dependency paths.
+    /// </summary>
+    [Fact]
+    public void StandaloneSolutionShouldContainExactlyOwnedProjects()
+    {
+        string repositoryRoot = FindRepositoryRoot();
+        var solution = XDocument.Load(Path.Combine(repositoryRoot, "Hexalith.Commons.Standalone.slnx"));
+        string[] projectPaths =
+        [
+            .. solution.Descendants("Project")
+            .Select(element => NormalizePath((string?)element.Attribute("Path")))
+            .Order(StringComparer.Ordinal),
+        ];
+
+        projectPaths.ShouldBe(ExpectedProjects.Order(StringComparer.Ordinal));
+        solution.Descendants()
+            .Where(element => element.Name.LocalName is "Project" or "File")
+            .Select(element => NormalizePath((string?)element.Attribute("Path")))
+            .ShouldAllBe(path => !path.StartsWith("references/", StringComparison.Ordinal));
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Hexalith.Commons.slnx")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName ?? throw new DirectoryNotFoundException("Could not locate the Hexalith.Commons repository root.");
+    }
+
+    private static string NormalizePath(string? path) =>
+        (path ?? throw new InvalidDataException("A solution entry is missing its Path attribute."))
+            .Replace('\\', '/');
+}


### PR DESCRIPTION
## Summary
- add a governance-only solution containing all 20 owned projects
- verify the solution inventory is discovered from disk
- document the isolated package-mode build command

## Verification
- isolated Release/package-mode restore and build: 0 warnings, 0 errors
- focused inventory test: 1/1 passed

## Parent rollout
Required by Hexalith.FrontComposer dependency-governance remediation for Actions run 30793884545.